### PR TITLE
Add Hugging Face fallback for trained DistilBERT model

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,8 +3,11 @@
 # Any missing key = safe mock fallback (the app never crashes).
 
 # --- Custom DistilBERT Model ---
-# Override if the model lives somewhere other than ../ml/clearconsent-distilbert-v2
+# Loading order: local dir → Hugging Face → rules-only fallback
+# Override local model path (default: ../ml/clearconsent-distilbert-v2)
 # CLEARCONSENT_MODEL_DIR=../ml/clearconsent-distilbert-v2
+# Override Hugging Face model ID (default: 1Ghoul1/clearconsent-distilbert-v2)
+# CLEARCONSENT_HF_MODEL_ID=1Ghoul1/clearconsent-distilbert-v2
 
 # --- Google Cloud Vision API (OCR) ---
 # Point to your service-account JSON file

--- a/backend/README.md
+++ b/backend/README.md
@@ -60,14 +60,29 @@ Every integration has a **real mode** (when the API key is set) and a **safe moc
 | Integration          | Env Var                          | Fallback Behaviour                          |
 | -------------------- | -------------------------------- | ------------------------------------------- |
 | Google Cloud Vision  | `GOOGLE_APPLICATION_CREDENTIALS` | Returns realistic mock OCR text             |
-| Custom DistilBERT    | `CLEARCONSENT_MODEL_DIR`         | Rule-based classifier only                  |
+| Custom DistilBERT    | `CLEARCONSENT_MODEL_DIR` / `CLEARCONSENT_HF_MODEL_ID` | Rule-based classifier only  |
 | Google Gemma / Gemini| `GEMINI_API_KEY`                 | Deterministic plain-English translations    |
 | Backboard            | `BACKBOARD_API_KEY`              | In-memory consent vault                     |
 | DCP / Distributive   | `DCP_API_KEY`                    | Simulated parallel timing metrics           |
 
 ## Custom ML Model
 
-The backend loads a fine-tuned **DistilBERT** model from `../ml/clearconsent-distilbert-v2`. This is a multi-label classifier trained on legal clause data that predicts 9 risk categories:
+The backend loads a fine-tuned **DistilBERT** model using a cascading strategy:
+
+1. **Local directory** — `CLEARCONSENT_MODEL_DIR` (default: `../ml/clearconsent-distilbert-v2`)
+2. **Hugging Face Hub** — `CLEARCONSENT_HF_MODEL_ID` (default: `1Ghoul1/clearconsent-distilbert-v2`)
+3. **Rules only** — If both sources fail, falls back to deterministic rule-based classification
+
+The `/health` endpoint reports which source was used:
+
+```json
+{
+  "model_loaded": true,
+  "model_source": "local"      // or "huggingface" or "rules_only"
+}
+```
+
+This is a multi-label classifier trained on legal clause data that predicts 9 risk categories:
 
 - WAIVER_OF_RIGHTS
 - ARBITRATION

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -101,7 +101,7 @@ app.include_router(history.router, prefix="/api")
 @app.get("/health", response_model=HealthResponse, tags=["Health"])
 async def health_check():
     """Health check endpoint — reports status and integration availability."""
-    from app.services.model_service import is_model_loaded, _load_model
+    from app.services.model_service import is_model_loaded, get_model_source, _load_model
 
     # Attempt to load the model if it hasn't been loaded yet
     _load_model()
@@ -110,6 +110,7 @@ async def health_check():
         status="healthy",
         version="1.0.0",
         model_loaded=is_model_loaded(),
+        model_source=get_model_source(),
         integrations={
             "google_vision": bool(
                 os.getenv("GOOGLE_APPLICATION_CREDENTIALS")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -88,4 +88,5 @@ class HealthResponse(BaseModel):
     status: str = "healthy"
     version: str = "1.0.0"
     model_loaded: bool = False
+    model_source: str = "rules_only"
     integrations: dict = {}

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -1,8 +1,12 @@
 """
 model_service.py — Hybrid clause classifier.
 
-Loads the custom DistilBERT model from ml/clearconsent-distilbert-v2 and
-combines it with deterministic rule-based predictions for must-catch
+Loads the custom DistilBERT model with a cascading strategy:
+  1. Local directory  (CLEARCONSENT_MODEL_DIR or ../ml/clearconsent-distilbert-v2)
+  2. Hugging Face Hub (CLEARCONSENT_HF_MODEL_ID or 1Ghoul1/clearconsent-distilbert-v2)
+  3. Rule-based only  (no model needed)
+
+Combines DistilBERT with deterministic rule-based predictions for must-catch
 categories (arbitration, waiver, financial liability, auto-renewal,
 liability limitation).
 """
@@ -13,18 +17,21 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Literal, Tuple
 
 logger = logging.getLogger("clearconsent.model")
 
 # ---------------------------------------------------------------------------
-# Model directory resolution
+# Model source resolution
 # ---------------------------------------------------------------------------
 
 _DEFAULT_MODEL_DIR = str(
     Path(__file__).resolve().parent.parent.parent.parent / "ml" / "clearconsent-distilbert-v2"
 )
 MODEL_DIR = os.getenv("CLEARCONSENT_MODEL_DIR", _DEFAULT_MODEL_DIR)
+
+_DEFAULT_HF_MODEL_ID = "1Ghoul1/clearconsent-distilbert-v2"
+HF_MODEL_ID = os.getenv("CLEARCONSENT_HF_MODEL_ID", _DEFAULT_HF_MODEL_ID)
 
 # ---------------------------------------------------------------------------
 # Lazy-loaded model & tokenizer (populated on first call)
@@ -34,11 +41,19 @@ _tokenizer = None
 _model = None
 _device = None
 _model_available = False
+_model_source: Literal["local", "huggingface", "rules_only"] = "rules_only"
 
 
 def _load_model() -> bool:
-    """Attempt to load the DistilBERT model once. Returns success flag."""
-    global _tokenizer, _model, _device, _model_available
+    """
+    Attempt to load the DistilBERT model once using a cascading strategy:
+      1. Local directory (CLEARCONSENT_MODEL_DIR)
+      2. Hugging Face Hub (CLEARCONSENT_HF_MODEL_ID)
+      3. Falls back to rules_only if both fail.
+
+    Returns True if the model was loaded successfully.
+    """
+    global _tokenizer, _model, _device, _model_available, _model_source
 
     if _model_available:
         return True
@@ -47,25 +62,74 @@ def _load_model() -> bool:
         import torch
         from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-        if not Path(MODEL_DIR).exists():
-            logger.warning("Model directory not found: %s", MODEL_DIR)
-            return False
-
         _device = "cuda" if torch.cuda.is_available() else "cpu"
-        _tokenizer = AutoTokenizer.from_pretrained(MODEL_DIR)
-        _model = AutoModelForSequenceClassification.from_pretrained(MODEL_DIR)
+
+        # --- Strategy 1: Local directory ---
+        local_path = Path(MODEL_DIR)
+        if local_path.exists() and any(local_path.iterdir()):
+            logger.info("Loading model from local directory: %s", MODEL_DIR)
+            _tokenizer = AutoTokenizer.from_pretrained(MODEL_DIR)
+            _model = AutoModelForSequenceClassification.from_pretrained(MODEL_DIR)
+            _model.to(_device)
+            _model.eval()
+            _model_available = True
+            _model_source = "local"
+            logger.info(
+                "DistilBERT loaded on %s from local path: %s", _device, MODEL_DIR
+            )
+            return True
+
+        logger.info(
+            "Local model directory not found or empty: %s — trying Hugging Face",
+            MODEL_DIR,
+        )
+
+    except Exception as exc:
+        logger.warning(
+            "Failed to load model from local directory: %s — trying Hugging Face",
+            exc,
+        )
+
+    # --- Strategy 2: Hugging Face Hub ---
+    try:
+        import torch
+        from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+        if _device is None:
+            _device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        logger.info("Loading model from Hugging Face: %s", HF_MODEL_ID)
+        _tokenizer = AutoTokenizer.from_pretrained(HF_MODEL_ID)
+        _model = AutoModelForSequenceClassification.from_pretrained(HF_MODEL_ID)
         _model.to(_device)
         _model.eval()
         _model_available = True
-        logger.info("DistilBERT loaded on %s from %s", _device, MODEL_DIR)
+        _model_source = "huggingface"
+        logger.info(
+            "DistilBERT loaded on %s from Hugging Face: %s", _device, HF_MODEL_ID
+        )
         return True
+
     except Exception as exc:
-        logger.warning("Could not load DistilBERT model: %s", exc)
-        return False
+        logger.warning(
+            "Failed to load model from Hugging Face (%s): %s — falling back to rules only",
+            HF_MODEL_ID,
+            exc,
+        )
+
+    # --- Strategy 3: Rules only ---
+    _model_source = "rules_only"
+    logger.info("Model unavailable — using rule-based classification only")
+    return False
 
 
 def is_model_loaded() -> bool:
     return _model_available
+
+
+def get_model_source() -> str:
+    """Return the source of the loaded model: 'local', 'huggingface', or 'rules_only'."""
+    return _model_source
 
 
 # ---------------------------------------------------------------------------

--- a/ml/README.md
+++ b/ml/README.md
@@ -1,0 +1,24 @@
+\# ClearConsent ML Model
+
+
+
+ClearConsent uses a custom DistilBERT model fine-tuned on CUAD-style legal clause data.
+
+
+
+The trained model artifacts are not committed to Git because they are large.
+
+
+
+\## Expected model path
+
+
+
+From the repo root, the backend expects the trained model at:
+
+
+
+```text
+
+ml/clearconsent-distilbert-v2
+

--- a/ml/upload_model_to_hf.py
+++ b/ml/upload_model_to_hf.py
@@ -1,0 +1,12 @@
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+
+LOCAL_MODEL_DIR = "./clearconsent-distilbert-v2"
+HF_REPO_ID = "1Ghoul1/clearconsent-distilbert-v2"
+
+tokenizer = AutoTokenizer.from_pretrained(LOCAL_MODEL_DIR)
+model = AutoModelForSequenceClassification.from_pretrained(LOCAL_MODEL_DIR)
+
+model.push_to_hub(HF_REPO_ID)
+tokenizer.push_to_hub(HF_REPO_ID)
+
+print(f"Uploaded model and tokenizer to https://huggingface.co/{HF_REPO_ID}")


### PR DESCRIPTION
## Summary

Adds model packaging documentation and updates the backend so the trained ClearConsent DistilBERT model can be loaded from Hugging Face when the local model folder is unavailable.

The trained model is hosted at:

`1Ghoul1/clearconsent-distilbert-v2`

## Changes

- Added cascading model loading:
  1. Try local model from `CLEARCONSENT_MODEL_DIR`
  2. Fall back to Hugging Face model from `CLEARCONSENT_HF_MODEL_ID`
  3. Fall back to rules-only mode if both fail
- Added `model_source` reporting to `/health`
- Updated backend schema to include `model_source`
- Updated `.env.example` with Hugging Face model configuration
- Updated backend README with model loading behavior
- Added ML README with model setup/training/testing instructions
- Added upload script for pushing the trained model to Hugging Face

## Verification

Tested locally:

- Local model loading works
- Hugging Face fallback works after temporarily renaming the local model folder
- `/health` reports `model_loaded: true`
- `/health` reports `model_source: "huggingface"` when local model is unavailable
- Backend still starts successfully without committing model artifacts to GitHub

## Notes

The trained model artifacts are intentionally not committed to GitHub because they are large. Teammates can load the model from Hugging Face instead.

Closes #5 