### PR TITLE
Add report generation and Gemma-powered explanations

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,7 +14,8 @@
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 # --- Google Gemini / Gemma API (plain-English explanations) ---
-# GEMINI_API_KEY=your-gemini-api-key-here
+GEMINI_API_KEY=your-gemini-api-key-here
+GEMMA_MODEL_NAME=gemma-4-31b-it
 
 # --- Backboard (consent vault persistence) ---
 # BACKBOARD_API_KEY=your-backboard-api-key-here

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -22,6 +22,8 @@ class FlaggedClause(BaseModel):
     severity: Literal["CRITICAL", "HIGH", "MEDIUM", "LOW"] = "MEDIUM"
     confidence: float = Field(..., ge=0.0, le=1.0)
     source: Literal["rule", "distilbert", "merged"] = "distilbert"
+    why_it_matters: Optional[str] = Field(None, description="Detailed explanation of the risk")
+    suggested_action: Optional[str] = Field(None, description="Recommended next step for the user")
 
 
 class ProcessingMetadata(BaseModel):

--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -104,12 +104,9 @@ async def analyze_document(
     # --- Step 4: Risk score ---
     risk_numeric, risk_label = model_service.compute_risk_score(flagged_raw)
 
-    # --- Step 5: Plain-English explanations ---
-    flagged_explained, used_gemma = await gemma_service.explain_clauses(flagged_raw)
-
-    # --- Step 6: Summary ---
-    summary, _ = await gemma_service.generate_summary(
-        flagged_explained, risk_numeric, risk_label
+    # --- Step 5: Plain-English explanations & Summary via Gemma ---
+    summary, flagged_explained, used_gemma = await gemma_service.improve_analysis_with_gemma(
+        flagged_raw, risk_numeric, risk_label
     )
 
     # --- Step 7: Build response ---
@@ -129,6 +126,8 @@ async def analyze_document(
             severity=c["severity"],
             confidence=c["confidence"],
             source=c["source"],
+            why_it_matters=c.get("why_it_matters"),
+            suggested_action=c.get("suggested_action"),
         )
         for c in flagged_explained
     ]
@@ -222,9 +221,8 @@ async def analyze_dcp(
     used_distilbert = model_service.is_model_loaded()
 
     risk_numeric, risk_label = model_service.compute_risk_score(flagged_raw)
-    flagged_explained, used_gemma = await gemma_service.explain_clauses(flagged_raw)
-    summary, _ = await gemma_service.generate_summary(
-        flagged_explained, risk_numeric, risk_label
+    summary, flagged_explained, used_gemma = await gemma_service.improve_analysis_with_gemma(
+        flagged_raw, risk_numeric, risk_label
     )
 
     elapsed_ms = int((time.perf_counter() - start) * 1000)
@@ -237,6 +235,8 @@ async def analyze_dcp(
             severity=c["severity"],
             confidence=c["confidence"],
             source=c["source"],
+            why_it_matters=c.get("why_it_matters"),
+            suggested_action=c.get("suggested_action"),
         )
         for c in flagged_explained
     ]

--- a/backend/app/services/gemma_service.py
+++ b/backend/app/services/gemma_service.py
@@ -1,15 +1,16 @@
 """
-gemma_service.py — LLM-powered plain-English explanations.
+gemma_service.py — LLM-powered plain-English explanations via Gemma.
 
-If GEMINI_API_KEY is set, calls the Google Gemini / Gemma API.
+If GEMINI_API_KEY is set, calls the Google GenAI API using Gemma models.
 Otherwise uses deterministic fallback translations so the demo always works.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
-from typing import List
+from typing import List, Optional, Tuple
 
 logger = logging.getLogger("clearconsent.gemma")
 
@@ -55,90 +56,161 @@ FALLBACK_SUMMARY_TEMPLATE = (
 )
 
 
-def _gemini_available() -> bool:
+def _is_api_configured() -> bool:
     key = os.getenv("GEMINI_API_KEY", "")
     return bool(key and not key.startswith("your-"))
 
 
+def _get_fallback_translation(clause_type: str) -> str:
+    return FALLBACK_TRANSLATIONS.get(
+        clause_type,
+        "This clause may contain terms that limit your rights or increase your obligations.",
+    )
+
+
 # ---------------------------------------------------------------------------
-# Real Gemini / Gemma calls
+# Real Gemma calls
 # ---------------------------------------------------------------------------
 
+async def improve_analysis_with_gemma(
+    flagged_clauses: List[dict], 
+    risk_score: int, 
+    risk_label: str
+) -> Tuple[str, List[dict], bool]:
+    """
+    Use Gemma to improve the analysis summary and clause translations.
+    Returns (summary, improved_clauses, used_gemma).
+    """
+    if not _is_api_configured():
+        return _apply_fallbacks(flagged_clauses, risk_score, risk_label)
 
-async def _gemini_explain(flagged_clauses: List[dict]) -> List[dict]:
-    """Use Gemini API to generate plain-English explanations."""
-    try:
-        from google import genai  # type: ignore
+    primary_model = os.getenv("GEMMA_MODEL_NAME", "gemma-4-31b-it")
+    fallback_model = "gemma-4-26b-a4b-it"
 
-        client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+    # Prepare input data for Gemma (limited context as requested)
+    input_data = {
+        "overall_risk_score": risk_label,
+        "risk_score_numeric": risk_score,
+        "flagged_clauses": [
+            {
+                "type": c["type"],
+                "severity": c["severity"],
+                "original_text": c["original_text"],
+                "fallback_translation": _get_fallback_translation(c["type"])
+            }
+            for c in flagged_clauses
+        ]
+    }
 
-        for clause in flagged_clauses:
-            if clause.get("translation"):
-                continue  # Already has a translation
+    prompt = f"""You are a consumer-rights legal assistant for Clarity.
+Your goal is to explain complex legal risks in plain, empathetic English.
 
-            prompt = (
-                "You are a consumer-rights assistant. Explain the following legal "
-                "clause in one or two plain-English sentences that a non-lawyer can "
-                "understand. Focus on what the signer is giving up or agreeing to.\n\n"
-                f"Category: {clause['type']}\n"
-                f"Clause: \"{clause['original_text']}\"\n\n"
-                "Plain-English explanation:"
-            )
+Input Data:
+{json.dumps(input_data, indent=2)}
 
+Task:
+1. Provide an overall executive summary (2-3 sentences).
+2. For each clause, provide a clear translation, why it matters, and a suggested action.
+
+Return ONLY strict JSON in this format:
+{{
+  "summary_plain_english": "...",
+  "clause_explanations": [
+    {{
+      "type": "...",
+      "translation": "...",
+      "why_it_matters": "...",
+      "suggested_action": "..."
+    }}
+  ]
+}}
+"""
+
+    for model_name in [primary_model, fallback_model]:
+        try:
+            from google import genai
+            from google.genai import types
+
+            client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+            
             response = client.models.generate_content(
-                model="gemma-3-4b-it",
+                model=model_name,
                 contents=prompt,
+                config=types.GenerateContentConfig(
+                    response_mime_type="application/json"
+                )
             )
-            clause["translation"] = response.text.strip()
 
-        return flagged_clauses
-    except Exception as exc:
-        logger.warning("Gemini explain failed: %s — using fallback", exc)
-        return _fallback_explain(flagged_clauses)
+            if not response or not response.text:
+                continue
 
+            # Parse JSON
+            try:
+                # Clean possible markdown wrap
+                raw_text = response.text.strip()
+                if raw_text.startswith("```json"):
+                    raw_text = raw_text.split("```json")[1].split("```")[0].strip()
+                elif raw_text.startswith("```"):
+                    raw_text = raw_text.split("```")[1].split("```")[0].strip()
+                
+                gemma_data = json.loads(raw_text)
+                
+                summary = gemma_data.get("summary_plain_english", "")
+                explanations = gemma_data.get("clause_explanations", [])
+                
+                # Merge Gemma explanations back into flagged_clauses
+                # We match by type and index to be safe if types repeat
+                improved_clauses = []
+                for i, c in enumerate(flagged_clauses):
+                    new_clause = c.copy()
+                    # Try to find matching explanation from Gemma
+                    if i < len(explanations):
+                        exp = explanations[i]
+                        new_clause["translation"] = exp.get("translation", _get_fallback_translation(c["type"]))
+                        new_clause["why_it_matters"] = exp.get("why_it_matters", "")
+                        new_clause["suggested_action"] = exp.get("suggested_action", "")
+                    else:
+                        new_clause["translation"] = _get_fallback_translation(c["type"])
+                    
+                    improved_clauses.append(new_clause)
 
-async def _gemini_summary(flagged_clauses: List[dict], risk_score: int, risk_label: str) -> str:
-    """Use Gemini API to generate an overall document summary."""
-    try:
-        from google import genai  # type: ignore
+                if not summary:
+                    summary = _fallback_summary(flagged_clauses, risk_score, risk_label)
 
-        client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+                logger.info("Successfully used Gemma model: %s", model_name)
+                return summary, improved_clauses, True
 
-        clause_descriptions = "\n".join(
-            f"- {c['type']}: \"{c['original_text'][:120]}...\"" for c in flagged_clauses
-        )
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning("Gemma JSON parse failed for model %s: %s", model_name, e)
+                continue
 
-        prompt = (
-            "You are a consumer-rights assistant. Summarize the risks of a legal "
-            "document in 2–3 plain-English sentences. The document has a risk score "
-            f"of {risk_score}/100 ({risk_label}).\n\n"
-            f"Flagged clauses:\n{clause_descriptions}\n\n"
-            "Summary:"
-        )
+        except Exception as exc:
+            logger.warning("Gemma call failed for model %s: %s", model_name, exc)
+            continue
 
-        response = client.models.generate_content(
-            model="gemma-3-4b-it",
-            contents=prompt,
-        )
-        return response.text.strip()
-    except Exception as exc:
-        logger.warning("Gemini summary failed: %s — using fallback", exc)
-        return _fallback_summary(flagged_clauses, risk_score, risk_label)
+    # If all models fail
+    return _apply_fallbacks(flagged_clauses, risk_score, risk_label)
 
 
 # ---------------------------------------------------------------------------
 # Fallback implementations
 # ---------------------------------------------------------------------------
 
-
-def _fallback_explain(flagged_clauses: List[dict]) -> List[dict]:
-    for clause in flagged_clauses:
-        if not clause.get("translation"):
-            clause["translation"] = FALLBACK_TRANSLATIONS.get(
-                clause["type"],
-                "This clause may contain terms that limit your rights or increase your obligations.",
-            )
-    return flagged_clauses
+def _apply_fallbacks(
+    flagged_clauses: List[dict], 
+    risk_score: int, 
+    risk_label: str
+) -> Tuple[str, List[dict], bool]:
+    """Helper to apply all fallbacks at once."""
+    improved_clauses = []
+    for c in flagged_clauses:
+        new_clause = c.copy()
+        if not new_clause.get("translation"):
+            new_clause["translation"] = _get_fallback_translation(c["type"])
+        improved_clauses.append(new_clause)
+    
+    summary = _fallback_summary(flagged_clauses, risk_score, risk_label)
+    return summary, improved_clauses, False
 
 
 def _fallback_summary(
@@ -160,31 +232,16 @@ def _fallback_summary(
 
 
 # ---------------------------------------------------------------------------
-# Public API
+# Deprecated/Compatibility API (Optional, keeping for internal references)
 # ---------------------------------------------------------------------------
 
-
 async def explain_clauses(flagged_clauses: List[dict]) -> tuple[List[dict], bool]:
-    """
-    Add plain-English translations to flagged clauses.
-    Returns (clauses_with_translations, used_gemma).
-    """
-    if _gemini_available():
-        result = await _gemini_explain(flagged_clauses)
-        return result, True
-
-    return _fallback_explain(flagged_clauses), False
-
+    # For backward compatibility if needed, but better to use the unified function
+    _, clauses, used = await improve_analysis_with_gemma(flagged_clauses, 0, "UNKNOWN")
+    return clauses, used
 
 async def generate_summary(
     flagged_clauses: List[dict], risk_score: int, risk_label: str
 ) -> tuple[str, bool]:
-    """
-    Generate a plain-English summary of the document.
-    Returns (summary_text, used_gemma).
-    """
-    if _gemini_available():
-        summary = await _gemini_summary(flagged_clauses, risk_score, risk_label)
-        return summary, True
-
-    return _fallback_summary(flagged_clauses, risk_score, risk_label), False
+    summary, _, used = await improve_analysis_with_gemma(flagged_clauses, risk_score, risk_label)
+    return summary, used

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,21 +1,72 @@
-# ClearConsent Backend — Python Dependencies
-# Install with: pip install -r requirements.txt
-
-# --- Core ---
-fastapi>=0.115.0
-uvicorn[standard]>=0.34.0
-python-dotenv>=1.1.0
-python-multipart>=0.0.20
-pydantic>=2.11.0
-httpx>=0.28.0
-
-# --- ML / Model ---
-torch>=2.0.0
-transformers>=4.40.0
-safetensors>=0.5.0
-
-# --- Google Cloud Vision (optional — install when using real OCR) ---
-# google-cloud-vision>=3.7.0
-
-# --- Google GenAI / Gemma (optional — install when using real LLM) ---
-# google-genai>=1.0.0
+annotated-doc==0.0.4
+annotated-types==0.7.0
+anyio==4.13.0
+certifi==2026.4.22
+cffi==2.0.0
+charset-normalizer==3.4.7
+click==8.3.3
+colorama==0.4.6
+cryptography==47.0.0
+defusedxml==0.7.1
+distro==1.9.0
+fastapi==0.136.1
+filelock==3.29.0
+fonttools==4.62.1
+fpdf2==2.8.7
+fsspec==2026.3.0
+google-api-core==2.30.3
+google-auth==2.49.2
+google-cloud-vision==3.13.0
+google-genai==1.73.1
+googleapis-common-protos==1.74.0
+grpcio==1.80.0
+grpcio-status==1.80.0
+h11==0.16.0
+hf-xet==1.4.3
+httpcore==1.0.9
+httptools==0.7.1
+httpx==0.28.1
+huggingface_hub==1.12.0
+idna==3.13
+Jinja2==3.1.6
+markdown-it-py==4.0.0
+MarkupSafe==3.0.3
+mdurl==0.1.2
+mpmath==1.3.0
+networkx==3.6.1
+numpy==2.4.4
+packaging==26.2
+pillow==12.2.0
+proto-plus==1.27.2
+protobuf==6.33.6
+pyasn1==0.6.3
+pyasn1_modules==0.4.2
+pycparser==3.0
+pydantic==2.13.3
+pydantic_core==2.46.3
+Pygments==2.20.0
+PyPDF2==3.0.1
+python-dotenv==1.2.2
+python-multipart==0.0.26
+PyYAML==6.0.3
+regex==2026.4.4
+requests==2.33.1
+rich==15.0.0
+safetensors==0.7.0
+setuptools==81.0.0
+shellingham==1.5.4
+sniffio==1.3.1
+starlette==1.0.0
+sympy==1.14.0
+tenacity==9.1.4
+tokenizers==0.22.2
+torch==2.11.0
+tqdm==4.67.3
+transformers==5.6.2
+typer==0.24.2
+typing-inspection==0.4.2
+typing_extensions==4.15.0
+urllib3==2.6.3
+uvicorn==0.46.0
+watchfiles==1.1.1
+websockets==16.0

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -532,43 +532,40 @@
                     <h2>Decision report</h2>
                 </div>
                 <div class="report-buttons">
-                    <button class="btn btn-secondary" id="copy-report-link">Copy link</button>
-                    <button class="btn btn-secondary" id="download-pdf">Download PDF</button>
+                    <button class="btn btn-secondary" id="copy-report-text">Copy report</button>
+                    <button class="btn btn-secondary" id="download-pdf">Download Report</button>
                     <button class="btn btn-primary" data-modal="lawyer">Send to lawyer</button>
                 </div>
             </div>
 
-            <div class="report-sheet reveal reveal-delay-2">
+            <div class="report-sheet reveal reveal-delay-2" id="report-sheet-content">
                 <div class="report-sheet-header">
                     <div>
                         <div class="eyebrow">Legal analysis report</div>
-                        <h3>Commercial Lease Agreement v2</h3>
-                        <p>Generated from the current document state. Replace this mock with backend report data when
-                            the analysis API is connected.</p>
+                        <h3 id="report-title">Commercial Lease Agreement v2</h3>
+                        <p id="report-subtitle">Generated from the current document state.</p>
                     </div>
                     <div class="mini-score">
-                        <div class="mini-score-number">75</div>
-                        <div class="mini-score-label">High risk</div>
+                        <div class="mini-score-number" id="report-score-number">75</div>
+                        <div class="mini-score-label" id="report-score-label">High risk</div>
                     </div>
                 </div>
 
                 <div class="report-grid">
-                    <div class="report-block">
+                    <div class="report-block full">
                         <h4>Executive summary</h4>
-                        <p>This document contains three clauses that materially change the risk profile of the
-                            agreement: uncapped liability, accelerated termination, and aggressive cost escalation.</p>
-                    </div>
-                    <div class="report-block">
-                        <h4>Top recommendation</h4>
-                        <p>Negotiate a liability cap, extend termination notice, and tie escalators to a market-normal
-                            benchmark before signing.</p>
+                        <p id="report-summary">This document contains three clauses...</p>
                     </div>
                     <div class="report-block full">
-                        <h4>Findings snapshot</h4>
-                        <ul class="report-list">
+                        <h4>Findings snapshot (<span id="report-total-flags">0</span>)</h4>
+                        <ul class="report-list" id="report-clauses">
                             <li>Critical: liability recovery window is unusually narrow</li>
-                            <li>Warning: termination can happen with only 24 hours notice</li>
-                            <li>Warning: annual cost escalation exceeds typical lease growth</li>
+                        </ul>
+                    </div>
+                    <div class="report-block full">
+                        <h4>Processing Metadata</h4>
+                        <ul class="report-list" id="report-metadata">
+                            <li>OCR Mode: pdf_text_extraction</li>
                         </ul>
                     </div>
                 </div>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -6,6 +6,7 @@ const state = {
   zoom: 100,
   scoreAnimated: false,
   isProcessing: false,
+  lastAnalysisData: null,
 };
 
 let clauses = [];
@@ -72,11 +73,11 @@ const modalContent = {
     body: `
       <p>Package the executive summary, top findings, and document anchors into a handoff your teammate can later connect to email or secure report delivery.</p>
       <div class="report-grid" style="margin-top:1rem">
-        <div class="report-block">
+        <div class="report-block action-block" id="modal-email-report" style="cursor:pointer">
           <h4>Email secure report</h4>
-          <p>Send the analysis and source-linked findings to counsel.</p>
+          <p>Send the analysis and source-linked findings to counsel via email.</p>
         </div>
-        <div class="report-block">
+        <div class="report-block action-block" id="modal-copy-summary" style="cursor:pointer">
           <h4>Copy judge-ready summary</h4>
           <p>Short version optimized for a live demo or quick legal opinion request.</p>
         </div>
@@ -101,7 +102,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const cameraCapture = document.getElementById("camera-capture");
   const processingContinue = document.getElementById("processing-continue");
   const saveToVault = document.getElementById("save-to-vault");
-  const copyReportLink = document.getElementById("copy-report-link");
+  const copyReportText = document.getElementById("copy-report-text");
   const downloadPdf = document.getElementById("download-pdf");
   const nextClause = document.getElementById("next-clause");
   const brandHome = document.getElementById("brand-home");
@@ -224,6 +225,14 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function setScreen(name) {
+    if (name === "report") {
+      if (!state.lastAnalysisData) {
+        showToast("Please analyze a document first.");
+        return;
+      }
+      generateReport();
+    }
+
     const isNewScreen = state.currentScreen !== name;
     state.currentScreen = name;
 
@@ -244,6 +253,50 @@ document.addEventListener("DOMContentLoaded", () => {
       } else {
         animateScore(state.score);
       }
+    }
+  }
+
+  function generateReport() {
+    const data = state.lastAnalysisData;
+    document.getElementById("report-title").textContent = state.uploadedFileName || "Document Analysis";
+    document.getElementById("report-score-number").textContent = data.risk_score_numeric;
+    document.getElementById("report-score-label").textContent = data.overall_risk_score;
+    
+    let summary = data.summary_plain_english || "No summary provided.";
+    if (data.flagged_clauses && data.flagged_clauses.length === 0) {
+      summary = "No risky clauses were detected. This does not replace professional legal advice, but no major red flags were found by Clarity.";
+    }
+    document.getElementById("report-summary").textContent = summary;
+    
+    document.getElementById("report-total-flags").textContent = data.flagged_clauses ? data.flagged_clauses.length : 0;
+    
+    const clausesList = document.getElementById("report-clauses");
+    clausesList.innerHTML = "";
+    if (data.flagged_clauses && data.flagged_clauses.length > 0) {
+      data.flagged_clauses.forEach(c => {
+        const li = document.createElement("li");
+        li.innerHTML = `<strong>${c.severity}: ${c.type}</strong><br><em>"${c.original_text}"</em><br>Meaning: ${c.translation || "N/A"} (${Math.round(c.confidence*100)}% confidence)`;
+        clausesList.appendChild(li);
+      });
+    } else {
+      const li = document.createElement("li");
+      li.textContent = "No flags detected.";
+      clausesList.appendChild(li);
+    }
+    
+    const metaList = document.getElementById("report-metadata");
+    metaList.innerHTML = "";
+    if (data.processing_metadata) {
+      const meta = data.processing_metadata;
+      metaList.innerHTML = `
+        <li>OCR Mode: ${meta.ocr_mode || "N/A"}</li>
+        <li>Model Source: ${meta.model_source || "N/A"}</li>
+        <li>Endpoint Mode: ${meta.endpoint_mode || "N/A"}</li>
+        <li>DistilBERT used: ${meta.used_distilbert}</li>
+        <li>Google Vision used: ${meta.used_google_vision}</li>
+        <li>Gemma used: ${meta.used_gemma}</li>
+        <li>Backboard used: ${meta.used_backboard}</li>
+      `;
     }
   }
 
@@ -293,7 +346,59 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+  function generateReportText() {
+    const data = state.lastAnalysisData;
+    if (!data) return "";
+    
+    let text = `Clarity Legal Analysis Report\n`;
+    text += `Document: ${state.uploadedFileName || "Document Analysis"}\n`;
+    text += `Risk Score: ${data.risk_score_numeric} (${data.overall_risk_score})\n\n`;
+    
+    let summary = data.summary_plain_english || "No summary provided.";
+    if (data.flagged_clauses && data.flagged_clauses.length === 0) {
+      summary = "No risky clauses were detected. This does not replace professional legal advice, but no major red flags were found by Clarity.";
+    }
+    text += `Executive Summary:\n${summary}\n\n`;
+    
+    text += `Findings Snapshot (${data.flagged_clauses ? data.flagged_clauses.length : 0}):\n`;
+    if (data.flagged_clauses && data.flagged_clauses.length > 0) {
+      data.flagged_clauses.forEach(c => {
+        text += `- ${c.severity}: ${c.type}\n`;
+        text += `  "${c.original_text}"\n`;
+        text += `  Meaning: ${c.translation || "N/A"} (${Math.round(c.confidence*100)}% confidence)\n\n`;
+      });
+    } else {
+      text += `- No flags detected.\n\n`;
+    }
+    
+    if (data.processing_metadata) {
+      text += `Processing Metadata:\n`;
+      const meta = data.processing_metadata;
+      text += `- OCR Mode: ${meta.ocr_mode || "N/A"}\n`;
+      text += `- Model Source: ${meta.model_source || "N/A"}\n`;
+      text += `- Endpoint Mode: ${meta.endpoint_mode || "N/A"}\n`;
+      text += `- DistilBERT used: ${meta.used_distilbert}\n`;
+      text += `- Google Vision used: ${meta.used_google_vision}\n`;
+    }
+    return text;
+  }
+
+  function generateJudgeSummary() {
+    const data = state.lastAnalysisData;
+    if (!data) return "";
+    const flaggedCount = data.flagged_clauses ? data.flagged_clauses.length : 0;
+    const criticalCount = data.flagged_clauses ? data.flagged_clauses.filter(c => c.severity === "CRITICAL").length : 0;
+    
+    let text = `CLARITY EXECUTIVE BRIEF\n`;
+    text += `Target: ${state.uploadedFileName}\n`;
+    text += `Verdict: ${data.overall_risk_score} (${data.risk_score_numeric}/100)\n`;
+    text += `Findings: ${flaggedCount} issues detected, including ${criticalCount} critical red flags.\n\n`;
+    text += `Summary: ${data.summary_plain_english || "Document analyzed with no major issues."}\n`;
+    return text;
+  }
+
   function mapApiResponse(data) {
+    state.lastAnalysisData = data;
     state.score = data.risk_score_numeric;
     state.riskLabel = data.overall_risk_score;
     
@@ -511,6 +616,28 @@ document.addEventListener("DOMContentLoaded", () => {
     modalShell.setAttribute("aria-hidden", "false");
 
     document.getElementById("modal-close")?.addEventListener("click", closeModal);
+    
+    if (key === "lawyer") {
+      document.getElementById("modal-email-report")?.addEventListener("click", () => {
+        const data = state.lastAnalysisData;
+        if (!data) {
+          showToast("No analysis to share.");
+          return;
+        }
+        const subject = encodeURIComponent(`Legal Risk Brief: ${state.uploadedFileName}`);
+        const body = encodeURIComponent(generateReportText());
+        window.location.href = `mailto:?subject=${subject}&body=${body}`;
+      });
+      
+      document.getElementById("modal-copy-summary")?.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(generateJudgeSummary());
+          showToast("Judge-ready summary copied.");
+        } catch {
+          showToast("Failed to copy summary.");
+        }
+      });
+    }
   }
 
   function closeModal() {
@@ -561,16 +688,39 @@ document.addEventListener("DOMContentLoaded", () => {
     setScreen("vault");
   });
 
-  copyReportLink.addEventListener("click", async () => {
+  copyReportText.addEventListener("click", async () => {
     try {
-      await navigator.clipboard.writeText(window.location.href);
-      showToast("Report link copied.");
+      const text = generateReportText();
+      if (!text) {
+        showToast("Please analyze a document first.");
+        return;
+      }
+      await navigator.clipboard.writeText(text);
+      showToast("Report copied to clipboard.");
     } catch {
-      showToast("Link ready to copy.");
+      showToast("Could not copy report.");
     }
   });
 
-  downloadPdf.addEventListener("click", () => showToast("PDF export hook ready for backend integration."));
+  downloadPdf.addEventListener("click", () => {
+    const text = generateReportText();
+    if (!text) {
+      showToast("Please analyze a document first.");
+      return;
+    }
+    
+    const blob = new Blob([text], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    const safeName = (state.uploadedFileName || "report").replace(/\.[^/.]+$/, "");
+    a.href = url;
+    a.download = `${safeName}_report.txt`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    showToast("Report downloaded as .txt");
+  });
   nextClause.addEventListener("click", () => {
     state.clauseIndex = (state.clauseIndex + 1) % clauses.length;
     updateClauseContent();

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -379,6 +379,8 @@ document.addEventListener("DOMContentLoaded", () => {
       text += `- Endpoint Mode: ${meta.endpoint_mode || "N/A"}\n`;
       text += `- DistilBERT used: ${meta.used_distilbert}\n`;
       text += `- Google Vision used: ${meta.used_google_vision}\n`;
+      text += `- Gemma used: ${meta.used_gemma}\n`;
+      text += `- Backboard used: ${meta.used_backboard}\n`;
     }
     return text;
   }


### PR DESCRIPTION
## Summary

Adds a complete report generation flow and Gemma-powered explanation support for Clarity analysis results.

## Changes

- Added deterministic legal analysis report generation from the latest analysis result
- Added Copy Report action
- Added Download Report action as a local `.txt` export
- Added Send to Lawyer / counsel handoff actions
- Added judge-ready summary copy support
- Added Gemma integration for improved executive summaries and clause explanations
- Added Gemma fallback behavior so analysis still works without API access
- Added optional fields for richer clause explanations
- Updated metadata export so reports include:
  - OCR mode
  - model source
  - endpoint mode
  - DistilBERT usage
  - Google Vision usage
  - Gemma usage
  - Backboard usage
- Updated requirements and `.env.example` for Gemma configuration

## Testing

Tested locally with backend on `localhost:8000`.

High-risk document:
- Returns `CRITICAL`
- Score `100`
- Shows 5 total flags
- Shows 4 critical flags
- Report includes flagged clauses, plain-English explanations, and processing metadata
- Gemma metadata shows `used_gemma: true`

Low-risk document:
- Returns `LOW`
- Score `0`
- Shows 0 flags
- Report shows no risky clauses detected
- Copy/download report uses the correct low-risk data
- Gemma metadata shows `used_gemma: true`

Report actions tested:
- Copy Report works
- Download Report works
- Send to Lawyer opens an email draft
- Copy judge-ready summary works

## Notes

`backend/.env` is intentionally not committed. Developers should set:

```env
GEMINI_API_KEY=your_key_here
GEMMA_MODEL_NAME=gemma-4-31b-it

Closes #7
Closes #14