### PR TITLE
Add Google Vision OCR for image uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ ml/**/*.bin
 backend/.venv/
 backend/venv/
 backend/**/*.env
+backend/credentials/
+backend/credentials/*.json
 
 # OS/editor
 .DS_Store

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,9 +9,11 @@
 # Override Hugging Face model ID (default: 1Ghoul1/clearconsent-distilbert-v2)
 # CLEARCONSENT_HF_MODEL_ID=1Ghoul1/clearconsent-distilbert-v2
 
-# --- Google Cloud Vision API (OCR) ---
-# Point to your service-account JSON file
-# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+# --- Google Cloud Vision API (OCR for image uploads: JPG, PNG, HEIC) ---
+# 1. Create a service account in Google Cloud Console with Vision AI User role.
+# 2. Download the JSON key and place it at backend/credentials/clarity-vision-key.json
+# 3. Set the path below (must be an absolute path).
+# GOOGLE_APPLICATION_CREDENTIALS=C:\Users\yourname\Downloads\Personal\Clarity\backend\credentials\clarity-vision-key.json
 
 # --- Google Gemini / Gemma API (plain-English explanations) ---
 GEMINI_API_KEY=your-gemini-api-key-here

--- a/backend/app/services/vision_service.py
+++ b/backend/app/services/vision_service.py
@@ -1,152 +1,227 @@
 """
-vision_service.py — Google Cloud Vision OCR with mock fallback.
+vision_service.py -- Google Cloud Vision OCR with smart fallback.
 
-If GOOGLE_APPLICATION_CREDENTIALS (or GOOGLE_CLOUD_VISION_KEY) is set, uses
-the real Vision API.  Otherwise returns realistic mock OCR text so the demo
-always works.
+Public API (consumed by app/routes/analyze.py):
+    extract_text_from_upload(file: UploadFile) -> tuple[str, bool, OcrMode]
+        Returns (extracted_text, used_google_vision, ocr_mode)
+
+Credential detection:
+    GOOGLE_APPLICATION_CREDENTIALS must be set AND point to a file that
+    actually exists on disk. If the env var is missing or is a placeholder,
+    Vision is marked unavailable and the caller is warned clearly.
+
+Cascade strategy (per upload):
+    PDFs:   PyPDF2 first; Vision as fallback for scanned/image-only PDFs.
+    Images: Vision when credentials are valid; 422 HTTPException otherwise.
+            Mock text is NEVER returned for real image uploads.
 """
 
 from __future__ import annotations
 
+import io
 import logging
 import os
-import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Tuple
 
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile
 
 logger = logging.getLogger("clearconsent.vision")
 
+OcrMode = Literal[
+    "google_vision",
+    "pdf_text_extraction",
+    "unsupported_image_no_vision",
+]
+
 # ---------------------------------------------------------------------------
-# Configuration check
+# Credential helpers
 # ---------------------------------------------------------------------------
+
+_PLACEHOLDERS = ("/path/to", "C:\\absolute\\", "your-", "/abs/")
+
+
+def _get_credentials_path() -> str | None:
+    creds = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+    if not creds:
+        return None
+    if any(creds.startswith(p) for p in _PLACEHOLDERS):
+        return None
+    return creds
 
 
 def _vision_available() -> bool:
-    """Return True when Google Cloud Vision credentials are configured."""
-    return bool(
-        os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-        or os.getenv("GOOGLE_CLOUD_VISION_KEY")
-    )
+    """
+    Return True only when GOOGLE_APPLICATION_CREDENTIALS is set (non-placeholder)
+    AND the file exists on disk.
+    """
+    creds = _get_credentials_path()
+    if not creds:
+        return False
+    exists = Path(creds).is_file()
+    if not exists:
+        logger.warning(
+            "GOOGLE_APPLICATION_CREDENTIALS is set to '%s' but the file does not exist. "
+            "Vision OCR will be unavailable.",
+            creds,
+        )
+    return exists
 
 
 # ---------------------------------------------------------------------------
-# Real Vision OCR
+# Google Cloud Vision OCR
 # ---------------------------------------------------------------------------
 
-
-async def _real_extract(file: UploadFile) -> str:
-    """Use Google Cloud Vision API to extract text from the uploaded file."""
+async def _vision_ocr(content: bytes, filename: str) -> str | None:
+    """
+    Call Vision API with raw file bytes.
+    Returns extracted text or None on failure / empty result.
+    """
     try:
         from google.cloud import vision  # type: ignore
 
         client = vision.ImageAnnotatorClient()
-
-        content = await file.read()
-        await file.seek(0)
-
         image = vision.Image(content=content)
-        response = client.text_detection(image=image)
+        response = client.document_text_detection(image=image)
 
         if response.error.message:
-            raise RuntimeError(response.error.message)
+            raise RuntimeError(f"Vision API error: {response.error.message}")
 
-        texts = response.text_annotations
-        if texts:
-            return texts[0].description
-        return ""
+        text = response.full_text_annotation.text
+        if text and text.strip():
+            logger.info(
+                "Google Vision extracted %d chars from '%s'", len(text), filename
+            )
+            return text.strip()
+
+        logger.warning("Google Vision returned empty text for '%s'", filename)
+        return None
+
     except Exception as exc:
-        logger.error("Vision API error: %s — returning None", exc)
+        logger.error("Vision API error: %s - returning None", exc)
         return None
 
 
 # ---------------------------------------------------------------------------
-# Mock OCR text — crafted to exercise every must-catch demo category
+# PDF text extraction
 # ---------------------------------------------------------------------------
-
-MOCK_OCR_TEXT = """PATIENT CONSENT AND TREATMENT AGREEMENT
-
-Acme Regional Medical Center — Patient Services Division
-
-Section 1: Consent to Treatment
-The patient hereby consents to the medical and surgical procedures recommended by their attending physician. The patient acknowledges that medicine is not an exact science and that no guarantees have been made regarding the outcome of treatment.
-
-Section 2: Waiver of Rights
-By signing this document, the patient agrees to waive the right to bring a lawsuit against Acme Regional Medical Center or its affiliated physicians. The patient releases the hospital from all claims, demands, and causes of action arising from treatment provided. The patient agrees not to sue the hospital or any staff member for any reason related to care received.
-
-Section 3: Arbitration Agreement
-Any dispute, claim, or controversy arising out of or relating to this agreement shall be resolved exclusively through binding arbitration administered by a neutral arbitrator. The patient agrees that claims will not be resolved through a jury trial or class action proceeding. This constitutes a class action waiver.
-
-Section 4: Financial Responsibility
-The patient accepts full financial responsibility for all charges, fees, deductibles, and unpaid balances not covered by insurance, including out-of-network provider fees. The patient agrees to indemnify and hold harmless the hospital from any costs, including reasonable attorney fees, incurred in collection efforts.
-
-Section 5: Auto-Renewal of Services
-This agreement will automatically renew for successive one-year terms unless either party provides written notice of cancellation at least thirty (30) days before the renewal term begins. The renewal term carries the same conditions as the initial agreement.
-
-Section 6: Limitation of Liability
-In no event shall Acme Regional Medical Center's total liability exceed the amount of fees paid by the patient in the twelve months preceding the claim. The hospital disclaims all liability for consequential damages, incidental damages, lost wages, or emotional distress arising from treatment.
-
-Section 7: General Provisions
-This agreement shall be governed by the laws of the State of California. The patient acknowledges that they have read, understood, and voluntarily agreed to the terms set forth herein. All notices required under this agreement shall be delivered in writing to the addresses on file.
-
-Patient Signature: _________________________  Date: ____________
-"""
-
-
-def _mock_text() -> str:
-    return MOCK_OCR_TEXT.strip()
-
-
-import io
-from typing import Literal
-
-# Type alias for OCR mode reporting
-OcrMode = Literal["google_vision", "pdf_text_extraction", "fallback_mock"]
 
 def _extract_pdf_text(content: bytes) -> str | None:
     """Extract text from a PDF using PyPDF2. Returns text or None."""
     try:
         from PyPDF2 import PdfReader
+
         reader = PdfReader(io.BytesIO(content))
-        pages_text = []
-        for page in reader.pages:
-            text = page.extract_text()
-            if text:
-                pages_text.append(text.strip())
+        pages_text = [
+            page.extract_text().strip()
+            for page in reader.pages
+            if page.extract_text()
+        ]
         full_text = "\n\n".join(pages_text).strip()
-        if len(full_text) > 20:
-            return full_text
-        return None
+        return full_text if len(full_text) > 20 else None
+
     except Exception as exc:
         logger.warning("PyPDF2 extraction failed: %s", exc)
         return None
 
-async def extract_text_from_upload(file: UploadFile) -> tuple[str, bool, OcrMode]:
+
+# ---------------------------------------------------------------------------
+# Public entry point — called by app/routes/analyze.py
+# ---------------------------------------------------------------------------
+
+async def extract_text_from_upload(
+    file: UploadFile,
+) -> Tuple[str, bool, OcrMode]:
     """
-    Extract text from an uploaded file using a cascading strategy.
-    Returns (extracted_text, used_google_vision, ocr_mode).
+    Extract text from an uploaded file.
+
+    Returns:
+        (extracted_text: str, used_google_vision: bool, ocr_mode: OcrMode)
+
+    Raises:
+        HTTPException 422 -- when text cannot be extracted and no mock is appropriate.
     """
     content = await file.read()
     await file.seek(0)
 
     filename = (file.filename or "").lower()
     is_pdf = filename.endswith(".pdf") or file.content_type == "application/pdf"
+    is_image = (
+        any(
+            filename.endswith(ext)
+            for ext in (".jpg", ".jpeg", ".png", ".heic", ".heif", ".tiff", ".bmp", ".webp")
+        )
+        or (file.content_type or "").startswith("image/")
+    )
 
-    if _vision_available():
-        logger.info("Attempting Google Cloud Vision OCR...")
-        text = await _real_extract(file)
-        if text:
-            return text, True, "google_vision"
-        logger.warning("Vision returned empty text; falling back")
+    vision_ready = _vision_available()
 
+    # ------------------------------------------------------------------
+    # PDF path
+    # ------------------------------------------------------------------
     if is_pdf:
         logger.info("Attempting local PDF text extraction (PyPDF2)...")
         text = _extract_pdf_text(content)
         if text:
             logger.info("PyPDF2 extracted %d chars from PDF", len(text))
             return text, False, "pdf_text_extraction"
-        logger.warning("PyPDF2 could not extract text (scanned PDF or image-only?)")
 
-    logger.warning("No text extraction succeeded for '%s' — returning mock OCR text.", file.filename)
-    return _mock_text(), False, "fallback_mock"
+        logger.warning(
+            "PyPDF2 could not extract text from '%s' (scanned/image-only PDF?). "
+            "Trying Vision if available.",
+            file.filename,
+        )
+        if vision_ready:
+            logger.info("Falling back to Google Vision for scanned PDF...")
+            text = await _vision_ocr(content, file.filename or "document.pdf")
+            if text:
+                return text, True, "google_vision"
+
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Could not extract text from the uploaded PDF. "
+                "The file may be scanned or image-only. "
+                "Enable Google Cloud Vision in the backend to process scanned PDFs."
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Image path
+    # ------------------------------------------------------------------
+    if is_image:
+        if vision_ready:
+            logger.info(
+                "Attempting Google Cloud Vision OCR for image '%s'...", file.filename
+            )
+            text = await _vision_ocr(content, file.filename or "image")
+            if text:
+                return text, True, "google_vision"
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "Google Vision could not extract any text from the uploaded image. "
+                    "Please ensure the image is clear and contains readable text."
+                ),
+            )
+
+        logger.warning(
+            "Image file '%s' uploaded but Google Cloud Vision is not configured. "
+            "Set GOOGLE_APPLICATION_CREDENTIALS in backend/.env to enable image OCR.",
+            file.filename,
+        )
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Image OCR is not available: Google Cloud Vision credentials are not configured. "
+                "Please upload a PDF, or contact the administrator to enable image OCR."
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Unknown file type
+    # ------------------------------------------------------------------
+    raise HTTPException(
+        status_code=400,
+        detail=f"Unsupported file type: '{file.filename}'. Please upload a PDF, JPG, or PNG.",
+    )

--- a/backend/test_vision_ocr.py
+++ b/backend/test_vision_ocr.py
@@ -1,0 +1,183 @@
+"""
+test_vision_ocr.py -- Sanity check for Google Cloud Vision OCR.
+
+Usage:
+  # Print credential status only:
+  python test_vision_ocr.py
+
+  # Also send a test image to Vision API:
+  python test_vision_ocr.py path\\to\\image.png
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sep(label: str = "") -> None:
+    if label:
+        print(f"\n--- {label} ---")
+    else:
+        print("-" * 50)
+
+
+def _ok(msg: str) -> None:
+    print(f"  [OK]   {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"  [FAIL] {msg}")
+
+
+def _warn(msg: str) -> None:
+    print(f"  [WARN] {msg}")
+
+
+def _info(msg: str) -> None:
+    print(f"  [INFO] {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Credential checks
+# ---------------------------------------------------------------------------
+
+def check_credentials() -> bool:
+    """Print a full credential status report. Returns True if Vision is ready."""
+    _sep("Google Cloud Vision -- Credential Status")
+
+    creds = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+
+    # 1. Is the env var set?
+    if not creds:
+        _fail("GOOGLE_APPLICATION_CREDENTIALS is not set.")
+        _info("Add it to backend/.env, e.g.:")
+        _info("  GOOGLE_APPLICATION_CREDENTIALS=C:\\...\\backend\\credentials\\clarity-vision-key.json")
+        return False
+    _ok(f"GOOGLE_APPLICATION_CREDENTIALS is set.")
+
+    # 2. Is it a placeholder?
+    placeholders = ("/path/to", "C:\\absolute\\", "your-", "/abs/")
+    if any(creds.startswith(p) for p in placeholders):
+        _fail(f"Value looks like a placeholder: '{creds}'")
+        _info("Replace the placeholder in backend/.env with the real absolute path.")
+        return False
+    _ok(f"Value does not look like a placeholder.")
+
+    # 3. Does the file exist?
+    path = Path(creds)
+    _info(f"Credential path: {creds}")
+    if not path.exists():
+        _fail(f"File does not exist at that path.")
+        return False
+    if not path.is_file():
+        _fail(f"Path exists but is not a file.")
+        return False
+    _ok(f"File exists ({path.stat().st_size:,} bytes).")
+
+    # 4. Can we import the Vision client?
+    _sep("Google Cloud Vision -- Import Check")
+    try:
+        from google.cloud import vision  # noqa: F401
+        _ok("google-cloud-vision package imported successfully.")
+    except ImportError as exc:
+        _fail(f"Cannot import google-cloud-vision: {exc}")
+        _info("Run: pip install google-cloud-vision")
+        return False
+
+    # 5. Can we instantiate the client?
+    try:
+        from google.cloud import vision as v
+        client = v.ImageAnnotatorClient()
+        _ok("ImageAnnotatorClient() instantiated successfully.")
+    except Exception as exc:
+        _fail(f"ImageAnnotatorClient() failed: {exc}")
+        return False
+
+    _sep()
+    _ok("Google Vision appears AVAILABLE. Image OCR is enabled.")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Live image test
+# ---------------------------------------------------------------------------
+
+def test_image(image_path: str) -> None:
+    _sep(f"Live API Test -- {image_path}")
+
+    path = Path(image_path)
+    if not path.is_file():
+        _fail(f"Image file not found: '{image_path}'")
+        return
+
+    _info(f"File size: {path.stat().st_size:,} bytes")
+
+    try:
+        from google.cloud import vision
+
+        client = vision.ImageAnnotatorClient()
+        content = path.read_bytes()
+        image = vision.Image(content=content)
+
+        _info("Sending to Vision API (document_text_detection)...")
+        response = client.document_text_detection(image=image)
+
+        if response.error.message:
+            _fail(f"Vision API error: {response.error.message}")
+            return
+
+        text = response.full_text_annotation.text
+        if text and text.strip():
+            preview = text.strip()[:300].replace("\n", " | ")
+            _ok(f"OCR succeeded! Extracted {len(text.strip())} characters.")
+            _info(f"Preview: \"{preview}\"")
+        else:
+            _warn("Vision API responded but extracted no text.")
+            _info("Check that the image is clear and contains readable text.")
+
+    except Exception as exc:
+        _fail(f"Vision API call failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    # Load .env from the backend directory
+    try:
+        from dotenv import load_dotenv
+        env_path = Path(__file__).parent / ".env"
+        if env_path.is_file():
+            load_dotenv(env_path)
+            _info(f"Loaded environment from: {env_path}")
+        else:
+            _warn(f"No .env found at {env_path} -- using system environment only.")
+    except ImportError:
+        _warn("python-dotenv not available -- using system environment only.")
+
+    print()
+
+    creds_ok = check_credentials()
+
+    if len(sys.argv) > 1:
+        if creds_ok:
+            test_image(sys.argv[1])
+        else:
+            _warn("Skipping live API test because credentials are not valid.")
+    else:
+        _sep()
+        _info("No image path provided. To test a live image upload, run:")
+        _info("  python test_vision_ocr.py path\\to\\image.png")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Google Cloud Vision OCR support for image-based document scans.

## Changes

- Added Google Vision OCR path for JPG/PNG/HEIC-style uploads
- Kept existing PDF text extraction path using PyPDF2
- Prevented real image uploads from falling back to hardcoded mock OCR text
- Added honest OCR metadata:
  - `ocr_mode: google_vision`
  - `used_google_vision: true`
- Added credential validation for `GOOGLE_APPLICATION_CREDENTIALS`
- Added `test_vision_ocr.py` for local credential and live OCR checks
- Updated `.env.example` and `.gitignore` for Vision credential setup

## Testing

Tested locally with a PNG scan:

- OCR mode: `google_vision`
- Google Vision used: `true`
- DistilBERT used: `true`
- Gemma used: `true`
- Risk score returned correctly as `CRITICAL / 100`
- Report generated successfully from image OCR output

PDF uploads still use:

- OCR mode: `pdf_text_extraction`
- Google Vision used: `false`

## Notes

`backend/.env` and `backend/credentials/clarity-vision-key.json` are intentionally not committed.

Closes #6 