### PR TITLE
Add vault history flow and scan UI polish

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,7 +21,7 @@ GEMMA_MODEL_NAME=gemma-4-31b-it
 
 # --- Backboard (consent vault persistence) ---
 # BACKBOARD_API_KEY=your-backboard-api-key-here
-# BACKBOARD_API_URL=https://api.backboard.dev
+# BACKBOARD_API_URL=https://app.backboard.io/api
 
 # --- DCP / Distributive Computing Protocol ---
 # DCP_API_KEY=your-dcp-api-key-here

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -81,6 +81,11 @@ class HistoryItem(BaseModel):
     risk_score_numeric: int
     flagged_count: int
     scanned_at: str  # ISO-8601 timestamp
+    
+    # Full analysis fields for detail view
+    summary_plain_english: Optional[str] = None
+    flagged_clauses: Optional[List[FlaggedClause]] = None
+    processing_metadata: Optional[ProcessingMetadata] = None
 
 
 class HistoryResponse(BaseModel):

--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -155,9 +155,13 @@ async def analyze_document(
     # --- Step 8: Save to vault ---
     analysis_dict = response.model_dump()
     analysis_dict["filename"] = file.filename or "Uploaded Document"
+    
     _, used_backboard = await backboard_service.save_document_analysis(
-        user_id or "demo_user", analysis_dict
+        user_id or "demo_user", 
+        analysis_dict
     )
+    
+    # Update the live response object with the final backboard status
     response.processing_metadata.used_backboard = used_backboard
 
     return response

--- a/backend/app/routes/history.py
+++ b/backend/app/routes/history.py
@@ -33,6 +33,10 @@ async def get_history(user_id: str):
             risk_score_numeric=item.get("risk_score_numeric", 50),
             flagged_count=item.get("flagged_count", 0),
             scanned_at=item.get("scanned_at", ""),
+            # Full fields for detail view
+            summary_plain_english=item.get("summary_plain_english"),
+            flagged_clauses=item.get("flagged_clauses"),
+            processing_metadata=item.get("processing_metadata"),
         )
         for item in items
     ]

--- a/backend/app/services/backboard_service.py
+++ b/backend/app/services/backboard_service.py
@@ -37,13 +37,13 @@ async def _real_save(user_id: str, analysis: dict) -> bool:
         import httpx
 
         api_key = os.getenv("BACKBOARD_API_KEY")
-        base_url = os.getenv("BACKBOARD_API_URL", "https://api.backboard.dev")
+        base_url = os.getenv("BACKBOARD_API_URL", "https://app.backboard.io/api")
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"{base_url}/api/documents",
+                f"{base_url}/documents",
                 headers={
-                    "Authorization": f"Bearer {api_key}",
+                    "X-API-Key": api_key,
                     "Content-Type": "application/json",
                 },
                 json={
@@ -71,12 +71,12 @@ async def _real_history(user_id: str) -> list[dict]:
         import httpx
 
         api_key = os.getenv("BACKBOARD_API_KEY")
-        base_url = os.getenv("BACKBOARD_API_URL", "https://api.backboard.dev")
+        base_url = os.getenv("BACKBOARD_API_URL", "https://app.backboard.io/api")
 
         async with httpx.AsyncClient() as client:
             response = await client.get(
-                f"{base_url}/api/documents",
-                headers={"Authorization": f"Bearer {api_key}"},
+                f"{base_url}/documents",
+                headers={"X-API-Key": api_key},
                 params={"user_id": user_id},
                 timeout=10.0,
             )
@@ -97,14 +97,13 @@ def _mock_save(user_id: str, analysis: dict) -> None:
     if user_id not in _mock_store:
         _mock_store[user_id] = []
 
-    _mock_store[user_id].append({
-        "document_id": analysis["document_id"],
-        "filename": analysis.get("filename", "Uploaded Document"),
-        "overall_risk_score": analysis["overall_risk_score"],
-        "risk_score_numeric": analysis["risk_score_numeric"],
-        "flagged_count": len(analysis.get("flagged_clauses", [])),
-        "scanned_at": datetime.now(timezone.utc).isoformat(),
-    })
+    record = analysis.copy()
+    record["scanned_at"] = datetime.now(timezone.utc).isoformat()
+    # Add helper field for frontend card rendering if missing
+    if "flagged_count" not in record:
+        record["flagged_count"] = len(analysis.get("flagged_clauses", []))
+        
+    _mock_store[user_id].append(record)
 
 
 def _mock_history(user_id: str) -> list[dict]:
@@ -120,6 +119,11 @@ def _mock_history(user_id: str) -> list[dict]:
             "overall_risk_score": "HIGH",
             "risk_score_numeric": 74,
             "flagged_count": 5,
+            "summary_plain_english": "High risk detected in liability waivers and arbitration requirements. This document significantly limits your right to sue for malpractice.",
+            "flagged_clauses": [
+                {"type": "Liability Limitation", "severity": "HIGH", "original_text": "Facility is not liable for any injury...", "translation": "They are trying to avoid paying if they hurt you.", "confidence": 0.95}
+            ],
+            "processing_metadata": {"ocr_mode": "pdf_text_extraction", "model_source": "distilbert", "endpoint_mode": "mock", "used_distilbert": True, "used_vision": False, "used_gemma": False, "used_backboard": False},
             "scanned_at": "2026-04-24T14:30:00Z",
         },
         {
@@ -128,6 +132,11 @@ def _mock_history(user_id: str) -> list[dict]:
             "overall_risk_score": "MEDIUM",
             "risk_score_numeric": 48,
             "flagged_count": 3,
+            "summary_plain_english": "Moderate risk found in security deposit return terms and early termination penalties.",
+            "flagged_clauses": [
+                {"type": "Termination Penalty", "severity": "MEDIUM", "original_text": "3 months rent penalty for early exit.", "translation": "Moving out early will cost you 3 months of rent.", "confidence": 0.88}
+            ],
+            "processing_metadata": {"ocr_mode": "pdf_text_extraction", "model_source": "distilbert", "endpoint_mode": "mock", "used_distilbert": True, "used_vision": False, "used_gemma": False, "used_backboard": False},
             "scanned_at": "2026-04-22T09:15:00Z",
         },
         {
@@ -136,6 +145,11 @@ def _mock_history(user_id: str) -> list[dict]:
             "overall_risk_score": "LOW",
             "risk_score_numeric": 22,
             "flagged_count": 1,
+            "summary_plain_english": "Low risk document. Standard at-will employment terms detected.",
+            "flagged_clauses": [
+                {"type": "At-Will Employment", "severity": "LOW", "original_text": "Employment may be terminated by either party...", "translation": "Either you or the company can end the job at any time.", "confidence": 0.92}
+            ],
+            "processing_metadata": {"ocr_mode": "pdf_text_extraction", "model_source": "distilbert", "endpoint_mode": "mock", "used_distilbert": True, "used_vision": False, "used_gemma": False, "used_backboard": False},
             "scanned_at": "2026-04-20T16:45:00Z",
         },
     ]
@@ -156,7 +170,10 @@ async def save_document_analysis(
     """
     if _backboard_available():
         ok = await _real_save(user_id, analysis)
-        return ok, True
+        if ok:
+            return True, True
+        # If it failed, it already fell back to mock in _real_save
+        return True, False
 
     _mock_save(user_id, analysis)
     return True, False

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -3096,8 +3096,343 @@ h4 {
   }
 
   .discovery-main {
+/* High-Impact Section Dividers */
+.section-divider {
+  width: 100%;
+  max-width: 1200px;
+  margin: 4rem auto 1rem;
+  display: flex;
+  align-items: center;
+  gap: 3rem;
+  padding: 0 2rem;
+}
+
+.section-divider::before,
+.section-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(to right, transparent, var(--cluely-blue), transparent);
+  opacity: 0.2;
+}
+
+.divider-text {
+  font-size: 3.5rem;
+  font-weight: 300;
+  font-family: var(--font-serif);
+  color: #000000;
+  letter-spacing: -0.03em;
+  white-space: nowrap;
+}
+
+.how-it-works {
+  padding: 2rem 0 4rem;
+  margin: 0;
+}
+
+/* Modern Insights Layout */
+.dashboard-shell {
+  margin: 2rem 0 5rem;
+}
+
+.discovery-hero {
+  display: block;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.discovery-main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 3rem;
+  padding: 5rem !important;
+}
+
+.discovery-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.discovery-actions {
+  display: flex;
+  justify-content: center;
+  gap: 1.2rem;
+  margin-top: 3rem;
+}
+
+.discovery-tags {
+  justify-content: center;
+}
+
+.discovery-main {
+  padding: 4rem !important;
+  display: flex;
+  gap: 4rem;
+  align-items: center;
+}
+
+.discovery-score {
+  flex-shrink: 0;
+}
+
+.discovery-copy h2 {
+  font-size: 3.2rem;
+  font-family: var(--font-serif);
+  font-weight: 400;
+  margin-bottom: 1.5rem;
+  letter-spacing: -0.02em;
+}
+
+.discovery-copy p {
+  font-size: 1.25rem;
+  line-height: 1.8;
+  color: var(--cluely-text-soft);
+  max-width: 45ch;
+  margin-bottom: 2.5rem;
+}
+
+.action-card-mini {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 1rem !important;
+  margin-top: 1.5rem;
+}
+
+.discovery-tags {
+  display: flex;
+  gap: 1rem;
+}
+
+.discovery-tag-pill {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 1.4rem;
+  background: var(--cluely-blue-soft);
+  border-radius: 100px;
+  font-size: 0.88rem;
+  font-weight: 800;
+  color: var(--cluely-blue);
+  letter-spacing: 0.02em;
+}
+
+.discovery-tag-pill.active.red {
+  background: rgba(220, 38, 38, 0.08);
+  color: #dc2626;
+}
+
+.discovery-side {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.bottom-line-card {
+  padding: 2.5rem !important;
+  flex: 1;
+}
+
+.bottom-line-card p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+}
+
+.btn-full {
+  width: 100%;
+}
+
+.dashboard-divider {
+  height: 1px;
+  background: var(--cluely-border);
+  margin: 4rem 0;
+  opacity: 0.5;
+}
+
+.section-header-compact {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(280px, 0.7fr);
+  align-items: end;
+  gap: 2.5rem;
+  margin-bottom: 3.5rem;
+  max-width: 980px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.section-title-group h3 {
+  font-size: 2.5rem;
+  font-family: var(--font-serif);
+  font-weight: 400;
+  margin-top: 0.5rem;
+  letter-spacing: -0.01em;
+}
+
+.section-header-compact p {
+  max-width: 32ch;
+  color: var(--cluely-text-soft);
+  font-size: 1.05rem;
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 1100px) {
+  .section-header-compact {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .discovery-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .discovery-main {
     flex-direction: column;
     text-align: center;
     gap: 2rem;
   }
+}
+/* Processing Screen Redesign */
+.processing-container {
+    max-width: 1100px;
+    margin: 6rem auto;
+    text-align: center;
+    padding: 0 2rem;
+}
+
+.processing-header {
+    margin-bottom: 4rem;
+}
+
+.processing-file-display {
+    font-size: 1.2rem;
+    font-weight: 500;
+    color: var(--cluely-text-soft);
+    margin-bottom: 0.8rem;
+}
+
+.processing-main-title {
+    font-size: clamp(2.5rem, 6vw, 4rem);
+    font-family: var(--font-serif);
+    font-weight: 300;
+    letter-spacing: -0.03em;
+    color: var(--cluely-text);
+}
+
+.process-steps-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 1.25rem;
+    margin-bottom: 4rem;
+}
+
+.process-step-card {
+    background: #ffffff;
+    border: 1px solid var(--cluely-border);
+    border-radius: 24px;
+    padding: 2.5rem 1.5rem;
+    text-align: center;
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+    opacity: 0.4;
+    filter: grayscale(1);
+    box-shadow: var(--shadow-sm);
+}
+
+.process-step-card.is-complete {
+    opacity: 1;
+    filter: grayscale(0);
+    border-color: rgba(59, 130, 246, 0.3);
+    background: rgba(59, 130, 246, 0.03);
+}
+
+.process-step-card.is-active {
+    opacity: 1;
+    filter: grayscale(0);
+    border-color: var(--cluely-blue);
+    background: #ffffff;
+    box-shadow: 0 20px 50px rgba(59, 130, 246, 0.12);
+    transform: translateY(-8px);
+}
+
+.step-badge {
+    width: 3.5rem;
+    height: 3.5rem;
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--cluely-text-soft);
+    transition: all 0.3s ease;
+}
+
+.step-badge .material-symbols-rounded {
+    font-size: 1.75rem;
+}
+
+.process-step-card.is-complete .step-badge {
+    background: var(--cluely-blue-soft);
+    color: var(--cluely-blue);
+}
+
+.process-step-card.is-active .step-badge {
+    background: var(--cluely-blue);
+    color: #ffffff;
+    animation: step-pulse 2s infinite;
+}
+
+.step-info h3 {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    color: var(--cluely-text);
+    letter-spacing: -0.01em;
+}
+
+.step-info p {
+    font-size: 0.85rem;
+    color: var(--cluely-text-soft);
+    line-height: 1.5;
+    max-width: 18ch;
+}
+
+.process-step-card.is-active .step-info p {
+    color: var(--cluely-text);
+}
+
+.processing-footer-actions {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+}
+
+@keyframes step-pulse {
+    0% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4); }
+    70% { box-shadow: 0 0 0 12px rgba(59, 130, 246, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
+}
+
+@media (max-width: 1024px) {
+    .process-steps-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (max-width: 768px) {
+    .process-steps-grid {
+        grid-template-columns: 1fr;
+        max-width: 400px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+    .processing-container {
+        margin: 3rem auto;
+    }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -173,71 +173,64 @@
         </section>
 
         <section class="screen" id="screen-processing" data-screen="processing">
-            <div class="processing-grid">
-                <div class="doc-preview glass-card reveal">
-                    <div class="doc-preview-header">
-                        <div class="eyebrow">Document in analysis</div>
-                        <h2 id="processing-file-name">Hospital_Consent_Form.pdf</h2>
-                    </div>
-                    <div class="doc-sheet">
-                        <div class="doc-scan-line"></div>
-                        <div class="doc-badge">ANALYSIS ACTIVE</div>
-                    </div>
-                    <p class="support-copy">Backend hook: replace this mock with the uploaded file name, page count,
-                        and Vision preview when your teammate connects the API.</p>
+            <div class="processing-container reveal">
+                <div class="processing-header">
+                    <div class="eyebrow">Document Analysis in Progress</div>
+                    <h2 id="processing-file-name" class="processing-file-display">Hospital_Consent_Form.pdf</h2>
+                    <h1 id="processing-title" class="processing-main-title">Building your decision brief</h1>
                 </div>
 
-                <div class="processing-panel glass-card reveal reveal-delay-2">
-                    <div class="panel-topline">
-                        <div>
-                            <div class="eyebrow">Decision brief pipeline</div>
-                            <h2 id="processing-title">Building your decision brief</h2>
+                <div class="process-steps-grid" id="process-steps">
+                    <div class="process-step-card is-complete">
+                        <div class="step-badge">
+                            <span class="material-symbols-rounded">check_circle</span>
                         </div>
-                        <span class="pill">Live</span>
+                        <div class="step-info">
+                            <h3>Reading layout</h3>
+                            <p>Identifying structure and zones.</p>
+                        </div>
                     </div>
+                    <div class="process-step-card is-complete">
+                        <div class="step-badge">
+                            <span class="material-symbols-rounded">check_circle</span>
+                        </div>
+                        <div class="step-info">
+                            <h3>Extracting text</h3>
+                            <p>Reading order preserved.</p>
+                        </div>
+                    </div>
+                    <div class="process-step-card is-active">
+                        <div class="step-badge">
+                            <span class="material-symbols-rounded">sync</span>
+                        </div>
+                        <div class="step-info">
+                            <h3>Detecting clauses</h3>
+                            <p id="processing-status">Scoring liability and waivers.</p>
+                        </div>
+                    </div>
+                    <div class="process-step-card">
+                        <div class="step-badge">
+                            <span class="material-symbols-rounded">pending</span>
+                        </div>
+                        <div class="step-info">
+                            <h3>Scoring risk</h3>
+                            <p>Calculating severity.</p>
+                        </div>
+                    </div>
+                    <div class="process-step-card">
+                        <div class="step-badge">
+                            <span class="material-symbols-rounded">auto_awesome</span>
+                        </div>
+                        <div class="step-info">
+                            <h3>Explaining findings</h3>
+                            <p>Generating plain language.</p>
+                        </div>
+                    </div>
+                </div>
 
-                    <div class="process-steps" id="process-steps">
-                        <div class="process-step is-complete">
-                            <div class="process-dot">check</div>
-                            <div>
-                                <h3>Reading layout</h3>
-                                <p>Paragraphs, signature zones, and document structure identified.</p>
-                            </div>
-                        </div>
-                        <div class="process-step is-complete">
-                            <div class="process-dot">check</div>
-                            <div>
-                                <h3>Extracting text</h3>
-                                <p>High-confidence OCR preserved in reading order.</p>
-                            </div>
-                        </div>
-                        <div class="process-step is-active">
-                            <div class="process-dot">sync</div>
-                            <div>
-                                <h3>Detecting clauses</h3>
-                                <p id="processing-status">Scoring liability, arbitration, and waiver language.</p>
-                            </div>
-                        </div>
-                        <div class="process-step">
-                            <div class="process-dot">radio_button_unchecked</div>
-                            <div>
-                                <h3>Scoring risk</h3>
-                                <p>Severity and confidence are being calculated.</p>
-                            </div>
-                        </div>
-                        <div class="process-step">
-                            <div class="process-dot">radio_button_unchecked</div>
-                            <div>
-                                <h3>Explaining in plain language</h3>
-                                <p>Rewriting the risky parts for a non-lawyer.</p>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="processing-actions">
-                        <button class="btn btn-ghost" data-screen="landing">Cancel</button>
-                        <button class="btn btn-primary" id="processing-continue">View early findings</button>
-                    </div>
+                <div class="processing-footer-actions">
+                    <button class="btn btn-secondary" data-screen="landing">Cancel Analysis</button>
+                    <button class="btn btn-primary" id="processing-continue">View early findings</button>
                 </div>
             </div>
         </section>
@@ -469,64 +462,31 @@
 
             <div class="vault-stats">
                 <div class="metric-card reveal">
-                    <div class="metric-value">24</div>
+                    <div class="metric-value" id="vault-stat-processed">0</div>
                     <div class="metric-label">Processed</div>
                 </div>
                 <div class="metric-card reveal reveal-delay-2">
-                    <div class="metric-value">02</div>
+                    <div class="metric-value" id="vault-stat-high-risk">00</div>
                     <div class="metric-label">High Risk</div>
                 </div>
                 <div class="metric-card reveal reveal-delay-3">
-                    <div class="metric-value">82%</div>
+                    <div class="metric-value" id="vault-stat-avg-score">0%</div>
                     <div class="metric-label">Average Score</div>
                 </div>
             </div>
 
-            <div class="vault-list">
-                <article class="vault-item glass-card reveal">
-                    <div class="vault-item-top">
-                        <div class="eyebrow vault-kicker">Recent scan</div>
-                        <div class="vault-score-badge high">
-                            <span class="vault-score-number">82</span>
-                            <span class="vault-score-copy">High risk</span>
-                        </div>
-                    </div>
-                    <div class="vault-info">
-                        <div class="vault-title">Mortgage Disclosure Agreement</div>
-                        <div class="vault-meta">First National Horizon Bank · Oct 24, 2026</div>
-                        <p class="vault-summary">Flagged liability exposure, accelerated repayment terms, and limited
-                            dispute windows.</p>
-                    </div>
-                    <div class="vault-buttons">
-                        <button class="btn btn-primary" data-screen="dashboard">Open analysis</button>
-                        <button class="btn btn-secondary" data-screen="report">View report</button>
-                    </div>
-                </article>
-
-                <article class="vault-item glass-card reveal reveal-delay-2">
-                    <div class="vault-item-top">
-                        <div class="eyebrow vault-kicker">Needs review</div>
-                        <div class="vault-score-badge medium">
-                            <span class="vault-score-number">61</span>
-                            <span class="vault-score-copy">Watchlist</span>
-                        </div>
-                    </div>
-                    <div class="vault-info">
-                        <div class="vault-title">Surgery Consent Form</div>
-                        <div class="vault-meta">North Shore Medical · Oct 22, 2026</div>
-                        <p class="vault-summary">Marked broad consent language and weak cancellation protections for
-                            follow-up.</p>
-                    </div>
-                    <div class="vault-buttons">
-                        <button class="btn btn-primary" data-screen="dashboard">Open analysis</button>
-                        <button class="btn btn-secondary" data-screen="report">View report</button>
-                    </div>
-                </article>
+            <div class="vault-list" id="vault-list-container">
+                <!-- Dynamic content will be injected here -->
             </div>
         </section>
 
         <section class="screen" id="screen-report" data-screen="report">
             <div class="report-toolbar reveal">
+                <div class="report-nav-actions" style="display: flex; gap: 1rem; margin-bottom: 0.5rem;">
+                    <button class="btn btn-secondary btn-large" data-screen="dashboard" style="padding: 0.6rem 1.2rem; font-size: 0.9rem;">← Back to Results</button>
+                    <button class="btn btn-secondary btn-large" data-screen="vault" style="padding: 0.6rem 1.2rem; font-size: 0.9rem;">View Vault</button>
+                    <button class="btn btn-secondary btn-large" data-screen="landing" style="padding: 0.6rem 1.2rem; font-size: 0.9rem;">Scan Another</button>
+                </div>
                 <div>
                     <div class="eyebrow">Shareable output</div>
                     <h2>Decision report</h2>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -7,6 +7,7 @@ const state = {
   scoreAnimated: false,
   isProcessing: false,
   lastAnalysisData: null,
+  vaultHistory: [],
 };
 
 let clauses = [];
@@ -254,17 +255,26 @@ document.addEventListener("DOMContentLoaded", () => {
         animateScore(state.score);
       }
     }
+
+    if (name === "vault") {
+      loadVaultHistory();
+    }
   }
 
   function generateReport() {
     const data = state.lastAnalysisData;
+    console.log("[Clarity] generateReport using object:", data);
     document.getElementById("report-title").textContent = state.uploadedFileName || "Document Analysis";
     document.getElementById("report-score-number").textContent = data.risk_score_numeric;
     document.getElementById("report-score-label").textContent = data.overall_risk_score;
     
-    let summary = data.summary_plain_english || "No summary provided.";
-    if (data.flagged_clauses && data.flagged_clauses.length === 0) {
-      summary = "No risky clauses were detected. This does not replace professional legal advice, but no major red flags were found by Clarity.";
+    let summary = data.summary_plain_english;
+    if (!summary) {
+      if (data.risk_score_numeric >= 70) {
+        summary = "CRITICAL ADVISORY: This document contains significant legal risks. While the detailed summary is unavailable for this specific historical record, the high risk score suggests extreme caution is required.";
+      } else {
+        summary = "Detailed plain-English summary is unavailable for this historical record.";
+      }
     }
     document.getElementById("report-summary").textContent = summary;
     
@@ -343,6 +353,91 @@ document.addEventListener("DOMContentLoaded", () => {
     } catch (error) {
       console.error("[Clarity] Real API call failed:", error);
       throw error;
+    }
+  }
+
+  async function loadVaultHistory() {
+    const endpoint = `${API_BASE}/api/history/demo_user`;
+    const container = document.getElementById("vault-list-container");
+    if (!container) return;
+
+    console.log(`[Clarity] Fetching vault history: ${endpoint}`);
+    
+    try {
+      const response = await fetch(endpoint);
+      if (!response.ok) throw new Error("Could not load vault history.");
+      
+      const data = await response.json();
+      console.log("[Clarity] Vault history response:", data);
+      
+      const documents = data.documents || [];
+      state.vaultHistory = documents;
+
+      // Update Stats
+      const processedCount = documents.length;
+      const highRiskCount = documents.filter(d => 
+        d.overall_risk_score === "HIGH" || 
+        d.overall_risk_score === "CRITICAL" || 
+        d.risk_score_numeric >= 70
+      ).length;
+      const avgScore = processedCount > 0 
+        ? Math.round(documents.reduce((acc, d) => acc + (d.risk_score_numeric || 0), 0) / processedCount) 
+        : 0;
+
+      const statProcessed = document.getElementById("vault-stat-processed");
+      const statHighRisk = document.getElementById("vault-stat-high-risk");
+      const statAvgScore = document.getElementById("vault-stat-avg-score");
+
+      if (statProcessed) statProcessed.textContent = processedCount;
+      if (statHighRisk) statHighRisk.textContent = highRiskCount.toString().padStart(2, '0');
+      if (statAvgScore) statAvgScore.textContent = `${avgScore}%`;
+      
+      if (documents.length === 0) {
+        container.innerHTML = `
+          <div class="empty-vault reveal">
+            <p>No saved documents yet. Scan a document to add it to your vault.</p>
+          </div>
+        `;
+        revealScreen(container);
+        return;
+      }
+
+      // Populate list
+      container.innerHTML = documents.map((doc, idx) => {
+        const date = doc.scanned_at ? new Date(doc.scanned_at).toLocaleDateString() : "Recent";
+        const riskClass = doc.overall_risk_score.toLowerCase();
+        const delay = idx > 0 ? `reveal-delay-${idx + 1}` : "";
+        
+        return `
+          <article class="vault-item glass-card reveal ${delay}">
+            <div class="vault-item-top">
+              <div class="eyebrow vault-kicker">${idx === 0 ? "Latest scan" : "History"}</div>
+              <div class="vault-score-badge ${riskClass}">
+                <span class="vault-score-number">${doc.risk_score_numeric}</span>
+                <span class="vault-score-copy">${doc.overall_risk_score}</span>
+              </div>
+            </div>
+            <div class="vault-info">
+              <div class="vault-title">${doc.filename || doc.document_id}</div>
+              <div class="vault-meta">Scanned on ${date}</div>
+              <p class="vault-summary">This document was analyzed with ${doc.flagged_count} flagged clauses.</p>
+            </div>
+            <div class="vault-buttons">
+              <button class="btn btn-secondary view-vault-details" data-id="${doc.document_id}">View Details</button>
+            </div>
+          </article>
+        `;
+      }).join("");
+
+      revealOnScroll();
+    } catch (error) {
+      console.error("[Clarity] Vault load error:", error);
+      container.innerHTML = `
+        <div class="error-vault reveal">
+          <p>Could not load your vault. Please try again later.</p>
+        </div>
+      `;
+      revealScreen(container);
     }
   }
 
@@ -563,6 +658,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     try {
         const data = await callAnalyzeReal(file);
+        console.log("[Clarity] POST /api/analyze response full keys:", Object.keys(data));
         
         processingStatus.textContent = "Drafting plain-English summary...";
         // artificial delay to let user read the status message
@@ -650,12 +746,25 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Event Delegation for Navigation and UI Triggers
   document.addEventListener("click", (event) => {
-    const target = event.target.closest("[data-screen], [data-modal], [data-toast]");
+    const target = event.target.closest("[data-screen], [data-modal], [data-toast], .view-vault-details");
     if (!target) return;
 
     if (target.dataset.screen) setScreen(target.dataset.screen);
     if (target.dataset.modal) openModal(target.dataset.modal);
     if (target.dataset.toast) showToast(target.dataset.toast);
+
+    if (target.classList.contains("view-vault-details")) {
+      const docId = target.dataset.id;
+      console.log(`[Clarity] Vault detail clicked: ${docId}`);
+      const doc = state.vaultHistory.find(d => d.document_id === docId);
+      console.log("[Clarity] Vault detail selected item:", doc);
+      if (doc) {
+        state.lastAnalysisData = doc;
+        console.log("[Clarity] Normalized vault detail object:", state.lastAnalysisData);
+        state.uploadedFileName = doc.filename || "Saved Analysis";
+        setScreen("report");
+      }
+    }
   });
 
   const headerScanTrigger = document.getElementById("header-scan-trigger");
@@ -686,7 +795,7 @@ document.addEventListener("DOMContentLoaded", () => {
   fileInput.addEventListener("change", (event) => handleFile(event.target.files?.[0]));
   processingContinue.addEventListener("click", () => setScreen("dashboard"));
   saveToVault.addEventListener("click", () => {
-    showToast("Analysis saved to Clarity Vault.");
+    showToast("Analysis saved available in Vault.");
     setScreen("vault");
   });
 


### PR DESCRIPTION
## Summary

Adds a functional Vault history flow and improves the scan/report navigation experience.

## Changes

- Loads Vault history from `GET /api/history/demo_user`
- Dynamically renders saved scans in the Vault screen
- Replaces hardcoded Vault stats with real calculated values
- Adds View Details behavior for saved scans
- Restores saved scans into active report state
- Keeps Copy Report, Download Report, and Send to Lawyer working from saved scans
- Preserves full analysis data in fallback/mock vault storage
- Adds honest Backboard metadata behavior so fallback/mock storage does not report as real Backboard usage
- Updates Google Vision OCR support and credential setup docs
- Adds `test_vision_ocr.py` for local Vision credential/OCR testing
- Improves scan processing screen styling/readability

## Testing

Tested locally with `vision_test.png`.

- Image scan used Google Vision OCR
- Gemma explanations worked
- Analysis returned CRITICAL / 100
- Vault displayed the saved scan
- Vault stats reflected real history
- View Details opened the saved report
- Copied report from Vault matched the visual report
- Copied report included correct metadata:
  - OCR Mode: `google_vision`
  - Google Vision used: `true`
  - Gemma used: `true`
  - Backboard used: `false` when external Backboard fell back

## Notes

External Backboard API currently returns 404 for `/documents`, so local/mock fallback is used. Metadata remains honest and reports `Backboard used: false` in that case.

Closes #8 