### PR TITLE
Polish Vault persistence, DCP metadata, and demo flow

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -60,6 +60,7 @@ class AnalysisResponse(BaseModel):
     risk_score_numeric: int = Field(..., ge=0, le=100)
     summary_plain_english: str
     flagged_clauses: List[FlaggedClause]
+    dcp_metrics: Optional[DCPMetrics] = None
     processing_metadata: ProcessingMetadata
 
 
@@ -86,6 +87,7 @@ class HistoryItem(BaseModel):
     # Full analysis fields for detail view
     summary_plain_english: Optional[str] = None
     flagged_clauses: Optional[List[FlaggedClause]] = None
+    dcp_metrics: Optional[DCPMetrics] = None
     processing_metadata: Optional[ProcessingMetadata] = None
 
 

--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -246,7 +246,7 @@ async def analyze_dcp(
         for c in flagged_explained
     ]
 
-    return DCPAnalysisResponse(
+    response = DCPAnalysisResponse(
         document_id=_make_doc_id(),
         overall_risk_score=risk_label,
         risk_score_numeric=risk_numeric,
@@ -266,3 +266,17 @@ async def analyze_dcp(
             endpoint_mode="real_analyze_dcp",
         ),
     )
+
+    # --- Step 8: Save to vault ---
+    analysis_dict = response.model_dump()
+    analysis_dict["filename"] = file.filename or "Uploaded Document (DCP)"
+    
+    _, used_backboard = await backboard_service.save_document_analysis(
+        user_id or "demo_user", 
+        analysis_dict
+    )
+    
+    # Update the live response object with the final backboard status
+    response.processing_metadata.used_backboard = used_backboard
+
+    return response

--- a/backend/app/routes/history.py
+++ b/backend/app/routes/history.py
@@ -36,6 +36,7 @@ async def get_history(user_id: str):
             # Full fields for detail view
             summary_plain_english=item.get("summary_plain_english"),
             flagged_clauses=item.get("flagged_clauses"),
+            dcp_metrics=item.get("dcp_metrics"),
             processing_metadata=item.get("processing_metadata"),
         )
         for item in items

--- a/backend/app/services/backboard_service.py
+++ b/backend/app/services/backboard_service.py
@@ -104,55 +104,14 @@ def _mock_save(user_id: str, analysis: dict) -> None:
         record["flagged_count"] = len(analysis.get("flagged_clauses", []))
         
     _mock_store[user_id].append(record)
+    logger.info("[Vault] Saved analysis for user %s: %s", user_id, record.get("filename", "unknown"))
 
 
 def _mock_history(user_id: str) -> list[dict]:
-    """Return in-memory history, or seed some demo entries."""
-    if user_id in _mock_store and _mock_store[user_id]:
-        return _mock_store[user_id]
-
-    # Seed demo data so the UI always has something to show
-    return [
-        {
-            "document_id": "doc_38201",
-            "filename": "Hospital_Consent_Form.pdf",
-            "overall_risk_score": "HIGH",
-            "risk_score_numeric": 74,
-            "flagged_count": 5,
-            "summary_plain_english": "High risk detected in liability waivers and arbitration requirements. This document significantly limits your right to sue for malpractice.",
-            "flagged_clauses": [
-                {"type": "Liability Limitation", "severity": "HIGH", "original_text": "Facility is not liable for any injury...", "translation": "They are trying to avoid paying if they hurt you.", "confidence": 0.95}
-            ],
-            "processing_metadata": {"ocr_mode": "pdf_text_extraction", "model_source": "distilbert", "endpoint_mode": "mock", "used_distilbert": True, "used_vision": False, "used_gemma": False, "used_backboard": False},
-            "scanned_at": "2026-04-24T14:30:00Z",
-        },
-        {
-            "document_id": "doc_29104",
-            "filename": "Apartment_Lease_Agreement.pdf",
-            "overall_risk_score": "MEDIUM",
-            "risk_score_numeric": 48,
-            "flagged_count": 3,
-            "summary_plain_english": "Moderate risk found in security deposit return terms and early termination penalties.",
-            "flagged_clauses": [
-                {"type": "Termination Penalty", "severity": "MEDIUM", "original_text": "3 months rent penalty for early exit.", "translation": "Moving out early will cost you 3 months of rent.", "confidence": 0.88}
-            ],
-            "processing_metadata": {"ocr_mode": "pdf_text_extraction", "model_source": "distilbert", "endpoint_mode": "mock", "used_distilbert": True, "used_vision": False, "used_gemma": False, "used_backboard": False},
-            "scanned_at": "2026-04-22T09:15:00Z",
-        },
-        {
-            "document_id": "doc_15773",
-            "filename": "Employment_Offer_Letter.pdf",
-            "overall_risk_score": "LOW",
-            "risk_score_numeric": 22,
-            "flagged_count": 1,
-            "summary_plain_english": "Low risk document. Standard at-will employment terms detected.",
-            "flagged_clauses": [
-                {"type": "At-Will Employment", "severity": "LOW", "original_text": "Employment may be terminated by either party...", "translation": "Either you or the company can end the job at any time.", "confidence": 0.92}
-            ],
-            "processing_metadata": {"ocr_mode": "pdf_text_extraction", "model_source": "distilbert", "endpoint_mode": "mock", "used_distilbert": True, "used_vision": False, "used_gemma": False, "used_backboard": False},
-            "scanned_at": "2026-04-20T16:45:00Z",
-        },
-    ]
+    """Return in-memory history."""
+    items = _mock_store.get(user_id, [])
+    logger.info("[Vault] Returning %d history items for %s", len(items), user_id)
+    return items
 
 
 # ---------------------------------------------------------------------------
@@ -168,11 +127,15 @@ async def save_document_analysis(
 
     Returns (success, used_backboard).
     """
+    filename = analysis.get("filename", "unknown")
+    logger.info("[Vault] Saving analysis for user %s: %s", user_id, filename)
+    
     if _backboard_available():
         ok = await _real_save(user_id, analysis)
         if ok:
             return True, True
         # If it failed, it already fell back to mock in _real_save
+        logger.info("[Vault] Backboard failed, saved to local fallback")
         return True, False
 
     _mock_save(user_id, analysis)

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -3312,8 +3312,7 @@ h4 {
     font-weight: 500;
     color: var(--cluely-text-soft);
     margin-bottom: 0.8rem;
-}
-
+} 
 .processing-main-title {
     font-size: clamp(2.5rem, 6vw, 4rem);
     font-family: var(--font-serif);
@@ -3324,25 +3323,29 @@ h4 {
 
 .process-steps-grid {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 1.25rem;
     margin-bottom: 4rem;
+    width: 100%;
+    align-items: stretch;
 }
 
 .process-step-card {
     background: #ffffff;
     border: 1px solid var(--cluely-border);
-    border-radius: 24px;
-    padding: 2.5rem 1.5rem;
+    border-radius: 20px;
+    padding: 2rem 1.2rem;
     text-align: center;
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1.25rem;
-    opacity: 0.4;
+    gap: 1rem;
+    opacity: 0.5;
     filter: grayscale(1);
     box-shadow: var(--shadow-sm);
+    font-family: var(--font-sans);
+    min-width: 160px;
 }
 
 .process-step-card.is-complete {
@@ -3394,13 +3397,15 @@ h4 {
     margin-bottom: 0.5rem;
     color: var(--cluely-text);
     letter-spacing: -0.01em;
+    font-family: var(--font-sans);
 }
 
 .step-info p {
     font-size: 0.85rem;
     color: var(--cluely-text-soft);
     line-height: 1.5;
-    max-width: 18ch;
+    max-width: 100%;
+    font-family: var(--font-sans);
 }
 
 .process-step-card.is-active .step-info p {
@@ -3427,134 +3432,160 @@ h4 {
 
 @media (max-width: 768px) {
     .process-steps-grid {
-        grid-template-columns: 1fr;
-        max-width: 400px;
-        margin-left: auto;
-        margin-right: auto;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        max-width: 100%;
     }
     .processing-container {
         margin: 3rem auto;
     }
 }
 
- / *   D C P   I n t e g r a t i o n   S t y l e s   * / 
- . d c p - t o g g l e - c o n t a i n e r   { 
-     m a r g i n - t o p :   2 r e m ; 
-     d i s p l a y :   f l e x ; 
-     f l e x - d i r e c t i o n :   c o l u m n ; 
-     g a p :   0 . 8 r e m ; 
- } 
- 
- . d c p - t o g g l e   { 
-     d i s p l a y :   f l e x ; 
-     a l i g n - i t e m s :   c e n t e r ; 
-     g a p :   1 . 2 r e m ; 
-     c u r s o r :   p o i n t e r ; 
-     b a c k g r o u n d :   v a r ( - - c l u e l y - g l a s s ) ; 
-     p a d d i n g :   0 . 8 r e m   1 . 6 r e m ; 
-     b o r d e r - r a d i u s :   1 0 0 p x ; 
-     b o r d e r :   1 p x   s o l i d   v a r ( - - c l u e l y - b o r d e r ) ; 
-     t r a n s i t i o n :   a l l   0 . 2 s   e a s e ; 
- } 
- 
- . d c p - t o g g l e : h o v e r   { 
-     b o r d e r - c o l o r :   v a r ( - - c l u e l y - b l u e ) ; 
-     b a c k g r o u n d :   v a r ( - - c l u e l y - g l a s s - h e a v y ) ; 
- } 
- 
- . d c p - t o g g l e   i n p u t   { 
-     d i s p l a y :   n o n e ; 
- } 
- 
- . d c p - s l i d e r   { 
-     w i d t h :   4 0 p x ; 
-     h e i g h t :   2 0 p x ; 
-     b a c k g r o u n d :   # c c c ; 
-     b o r d e r - r a d i u s :   2 0 p x ; 
-     p o s i t i o n :   r e l a t i v e ; 
-     t r a n s i t i o n :   0 . 3 s ; 
- } 
- 
- . d c p - s l i d e r : b e f o r e   { 
-     c o n t e n t :   ' ' ; 
-     p o s i t i o n :   a b s o l u t e ; 
-     w i d t h :   1 6 p x ; 
-     h e i g h t :   1 6 p x ; 
-     b a c k g r o u n d :   w h i t e ; 
-     b o r d e r - r a d i u s :   5 0 % ; 
-     t o p :   2 p x ; 
-     l e f t :   2 p x ; 
-     t r a n s i t i o n :   0 . 3 s ; 
- } 
- 
- . d c p - t o g g l e   i n p u t : c h e c k e d   +   . d c p - s l i d e r   { 
-     b a c k g r o u n d :   v a r ( - - c l u e l y - b l u e ) ; 
- } 
- 
- . d c p - t o g g l e   i n p u t : c h e c k e d   +   . d c p - s l i d e r : b e f o r e   { 
-     l e f t :   2 2 p x ; 
- } 
- 
- . d c p - l a b e l   { 
-     f o n t - w e i g h t :   5 0 0 ; 
-     f o n t - s i z e :   0 . 9 5 r e m ; 
- } 
- 
- . d c p - h e l p e r   { 
-     f o n t - s i z e :   0 . 8 5 r e m ; 
-     c o l o r :   v a r ( - - c l u e l y - t e x t - s o f t ) ; 
-     m a x - w i d t h :   4 0 0 p x ; 
- } 
- 
- . d c p - m e t r i c s - c a r d   { 
-     b a c k g r o u n d :   v a r ( - - c l u e l y - g l a s s ) ; 
-     b o r d e r :   1 p x   s o l i d   v a r ( - - c l u e l y - b o r d e r ) ; 
-     b o r d e r - r a d i u s :   1 . 5 r e m ; 
-     p a d d i n g :   1 . 5 r e m ; 
-     m a r g i n - b o t t o m :   1 r e m ; 
- } 
- 
- . d c p - m e t r i c s - h e a d e r   { 
-     d i s p l a y :   f l e x ; 
-     a l i g n - i t e m s :   c e n t e r ; 
-     g a p :   0 . 8 r e m ; 
-     m a r g i n - b o t t o m :   1 . 5 r e m ; 
- } 
- 
- . d c p - m e t r i c s - h e a d e r   . m a t e r i a l - s y m b o l s - r o u n d e d   { 
-     c o l o r :   v a r ( - - c l u e l y - b l u e ) ; 
-     f o n t - s i z e :   1 . 8 r e m ; 
- } 
- 
- . d c p - m e t r i c s - h e a d e r   h 4   { 
-     m a r g i n :   0 ; 
-     f l e x - g r o w :   1 ; 
- } 
- 
- . d c p - m e t r i c s - g r i d   { 
-     d i s p l a y :   g r i d ; 
-     g r i d - t e m p l a t e - c o l u m n s :   r e p e a t ( 4 ,   1 f r ) ; 
-     g a p :   1 r e m ; 
- } 
- 
- . d c p - m e t r i c   { 
-     t e x t - a l i g n :   c e n t e r ; 
- } 
- 
- . d c p - m e t r i c - v a l   { 
-     f o n t - s i z e :   1 . 5 r e m ; 
-     f o n t - w e i g h t :   6 0 0 ; 
-     m a r g i n - b o t t o m :   0 . 2 r e m ; 
- } 
- 
- . d c p - m e t r i c - l a b e l   { 
-     f o n t - s i z e :   0 . 7 5 r e m ; 
-     t e x t - t r a n s f o r m :   u p p e r c a s e ; 
-     l e t t e r - s p a c i n g :   0 . 0 5 e m ; 
-     c o l o r :   v a r ( - - c l u e l y - t e x t - s o f t ) ; 
- } 
- 
- . t e x t - a c c e n t   {   c o l o r :   v a r ( - - c l u e l y - b l u e ) ;   } 
- . t e x t - s u c c e s s   {   c o l o r :   # 2 e 7 d 3 2 ;   } 
-  
- 
+/* DCP Polished Hero Control */
+.dcp-hero-control {
+    margin-top: 5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.8rem;
+    width: 100%;
+}
+
+.dcp-pill {
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    padding: 0.6rem 1.4rem;
+    border-radius: 100px;
+    display: flex;
+    align-items: center;
+    gap: 1.2rem;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.05);
+    transition: all 0.3s ease;
+}
+
+.dcp-pill:hover {
+    background: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.dcp-pill-label {
+    color: rgba(255, 255, 255, 0.95);
+    font-size: 0.9rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+}
+
+.dcp-pill-help {
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.75rem;
+    margin: 0;
+    font-weight: 400;
+    max-width: 400px;
+    text-align: center;
+}
+
+/* Custom Switch for Hero */
+.dcp-switch {
+  position: relative;
+  display: inline-block;
+  width: 38px;
+  height: 20px;
+}
+
+.dcp-switch input#dcp-toggle-input { 
+  opacity: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+  position: absolute !important;
+  pointer-events: none;
+}
+
+.dcp-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(255, 255, 255, 0.2);
+  transition: .3s;
+}
+
+.dcp-slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: .3s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+input:checked + .dcp-slider {
+  background-color: var(--cluely-blue);
+}
+
+input:checked + .dcp-slider:before {
+  transform: translateX(18px);
+}
+
+.dcp-slider.round {
+  border-radius: 34px;
+}
+
+.dcp-slider.round:before {
+  border-radius: 50%;
+}
+
+.dcp-metrics-card {
+    background: var(--cluely-glass);
+    border: 1px solid var(--cluely-border);
+    border-radius: 1.5rem;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.dcp-metrics-header {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+}
+
+.dcp-metrics-header .material-symbols-rounded {
+    color: var(--cluely-blue);
+    font-size: 1.8rem;
+}
+
+.dcp-metrics-header h4 {
+    margin: 0;
+    flex-grow: 1;
+}
+
+.dcp-metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+}
+
+.dcp-metric {
+    text-align: center;
+}
+
+.dcp-metric-val {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 0.2rem;
+}
+
+.dcp-metric-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--cluely-text-soft);
+}
+
+.text-accent { color: var(--cluely-blue); }
+.text-success { color: #2e7d32; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,13 +55,15 @@
                     <button class="btn btn-secondary btn-large" data-screen="vault">View Vault</button>
                 </div>
 
-                <div class="dcp-toggle-container centered reveal reveal-delay-2">
-                    <label class="dcp-toggle">
-                        <input type="checkbox" id="dcp-toggle-input">
-                        <span class="dcp-slider"></span>
-                        <span class="dcp-label">Use DCP parallel processing</span>
-                    </label>
-                    <p class="dcp-helper">Splits long documents into page chunks and estimates parallel analysis speedup.</p>
+                <div class="dcp-hero-control reveal reveal-delay-2">
+                    <div class="dcp-pill">
+                        <span class="dcp-pill-label">Use DCP parallel processing</span>
+                        <label class="dcp-switch">
+                            <input type="checkbox" id="dcp-toggle-input">
+                            <span class="dcp-slider round"></span>
+                        </label>
+                    </div>
+                    <p class="dcp-pill-help">Splits long documents into page chunks and estimates parallel analysis speedup.</p>
                 </div>
 
                 <div class="how-it-works reveal reveal-delay-3">
@@ -264,24 +266,23 @@
                                             <circle class="ring-progress" cx="110" cy="110" r="92"></circle>
                                         </svg>
                                         <div class="score-center">
-                                            <div class="score-number" id="score-number">82</div>
+                                            <div class="score-number" id="score-number">--</div>
                                             <div class="score-label">Risk Score</div>
                                         </div>
                                     </div>
                                 </div>
                                 <div class="discovery-copy">
                                     <div class="eyebrow">Executive Verdict</div>
-                                    <h2 id="discovery-headline">High-Risk Exposure Detected</h2>
-                                    <p id="discovery-summary">This document contains asymmetric liability structures and aggressive termination
-                                        hooks. We recommend a professional legal review before execution.</p>
+                                    <h2 id="discovery-headline">Analysis Complete</h2>
+                                    <p id="discovery-summary">The document has been reviewed. See the flagged clauses below.</p>
                                     <div class="discovery-tags">
                                         <div class="discovery-tag-pill active red" id="critical-flags-pill">
                                             <span class="material-symbols-rounded">warning</span>
-                                            <span id="critical-flags-count">3 Critical Flags</span>
+                                            <span id="critical-flags-count">0 Flags</span>
                                         </div>
                                         <div class="discovery-tag-pill" id="standard-clauses-pill">
                                             <span class="material-symbols-rounded">verified</span>
-                                            <span id="standard-clauses-count">14 Standard Clauses</span>
+                                            <span id="standard-clauses-count">0 Clauses</span>
                                         </div>
                                     </div>
                                     <div class="discovery-actions">
@@ -535,8 +536,7 @@
                         <div class="dcp-metrics-card">
                             <div class="dcp-metrics-header">
                                 <span class="material-symbols-rounded">speed</span>
-                                <h4 id="report-dcp-title">DCP Parallel Speedup</h4>
-                                <span class="badge" id="report-dcp-mode">Simulated</span>
+                                <h4 id="report-dcp-title">DCP Parallel Acceleration</h4>
                             </div>
                             <div class="dcp-metrics-grid">
                                 <div class="dcp-metric">

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -299,16 +299,7 @@ document.addEventListener("DOMContentLoaded", () => {
       document.getElementById("report-dcp-para").textContent = `${(dcp.dcp_parallel_time_ms / 1000).toFixed(1)}s`;
       document.getElementById("report-dcp-speedup").textContent = `${dcp.speedup_factor}x`;
       
-      const modeBadge = document.getElementById("report-dcp-mode");
-      if (meta.dcp_mode === "accelerated_fallback" || meta.dcp_mode === "simulated") {
-        modeBadge.textContent = "Accelerated";
-        modeBadge.style.background = "var(--cluely-glass-heavy)";
-        document.getElementById("report-dcp-title").textContent = "DCP Parallel Acceleration";
-      } else {
-        modeBadge.textContent = "DCP Active";
-        modeBadge.style.background = "var(--cluely-blue)";
-        document.getElementById("report-dcp-title").textContent = "DCP Parallel Acceleration";
-      }
+      document.getElementById("report-dcp-title").textContent = "DCP Parallel Acceleration";
     } else {
       dcpContainer.style.display = "none";
     }
@@ -415,7 +406,12 @@ document.addEventListener("DOMContentLoaded", () => {
       const data = await response.json();
       console.log("[Clarity] Vault history response:", data);
       
-      const documents = data.documents || [];
+      // Sort by scanned_at descending (newest first)
+      const documents = (data.documents || []).sort((a, b) => {
+        const dateA = a.scanned_at ? new Date(a.scanned_at) : 0;
+        const dateB = b.scanned_at ? new Date(b.scanned_at) : 0;
+        return dateB - dateA;
+      });
       state.vaultHistory = documents;
 
       // Update Stats


### PR DESCRIPTION
## Summary

Final demo polish pass for Clarity. This PR improves the Vault save/restore flow, preserves DCP acceleration metadata across saved reports, removes seeded demo Vault data, and cleans up small UI/report issues.

## Changes

- Fixed Vault fallback persistence when Backboard is unavailable
- Removed hardcoded/demo Vault documents from fallback storage
- Ensured Vault starts empty and only shows real scanned documents
- Added dynamic Vault stats:
  - processed count
  - high-risk count
  - average score
- Fixed Vault ordering so newest scans appear first
- Preserved full report data when opening saved Vault items
- Preserved DCP acceleration metrics in saved reports
- Ensured copied/downloaded reports match fresh and Vault-opened reports
- Removed faint DCP badge from the report card
- Added/updated DCP environment documentation in `.env.example`
- Minor landing/demo UI cleanup

## Testing

Tested locally with:

- Low-risk PDF
- High-risk PDF
- PNG/image scan using Google Vision OCR
- DCP acceleration mode enabled
- Vault save and restore flow
- Copy report from fresh report and Vault-opened report

Verified:

- Fresh scan reports match Vault-restored reports
- Vault only shows real scanned documents
- Vault stats update correctly
- View Details opens the correct saved report
- DCP metadata and speedup metrics persist through Vault
- Google Vision OCR is used for image uploads
- Gemma summaries/explanations still generate correctly

## Notes

Backboard external API still falls back locally when unavailable, but the Vault remains fully functional through the fallback store.